### PR TITLE
Remove Redis and add Overcommit configuration

### DIFF
--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -1,0 +1,28 @@
+# Use this file to configure the Overcommit hooks you wish to use. This will
+# extend the default configuration defined in:
+# https://github.com/sds/overcommit/blob/main/config/default.yml
+#
+# At the topmost level of this YAML file is a key representing type of hook
+# being run (e.g. pre-commit, commit-msg, etc.). Within each type you can
+# customize each hook, such as whether to only run it on certain files (via
+# `include`), whether to only display output if it fails (via `quiet`), etc.
+#
+# For a complete list of hooks, see:
+# https://github.com/sds/overcommit/tree/main/lib/overcommit/hook
+#
+# For a complete list of options that you can use to customize hooks, see:
+# https://github.com/sds/overcommit#configuration
+#
+# Uncomment the following lines to make the configuration take effect.
+
+verify_signatures: false
+
+PreCommit:
+  RuboCop:
+    enabled: true
+    required: true
+    command: ['bundle', 'exec', 'rubocop', '-f', 'simple']
+  ErbLint:
+    enabled: true
+    required: true
+    command: ['bundle', 'exec', 'erblint', '--lint-all']

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Then you can start the database servers:
 
 ```bash
 brew services start postgresql
-brew services start redis
 ```
 
 ## Initial Setup


### PR DESCRIPTION
## Summary
- Remove `brew services start redis` from README since Redis is no longer needed (project uses Solid Queue/Cable/Cache)
- Add `.overcommit.yml` with RuboCop and ErbLint pre-commit hooks

## Test plan
- [ ] Verify pre-commit hooks run correctly with `overcommit --install && overcommit --run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)