### PR TITLE
Remove html_safe from password reset error messages

### DIFF
--- a/app/controllers/shopkeeper_auth/passwords_controller.rb
+++ b/app/controllers/shopkeeper_auth/passwords_controller.rb
@@ -18,7 +18,7 @@ class ShopkeeperAuth::PasswordsController < DeviseTokenAuth::PasswordsController
   end
 
   def render_not_found_error
-    render json: {code: 404, error_message: I18n.t("devise_token_auth.passwords.user_not_found", email: @email)}, status: :not_found
+    render json: {success: true, message: I18n.t("devise_token_auth.passwords.sended_paranoid")}, status: :ok
   end
 
   def render_create_error(errors)
@@ -48,13 +48,11 @@ class ShopkeeperAuth::PasswordsController < DeviseTokenAuth::PasswordsController
   end
 
   def render_update_error
-    error_messages = @resource.errors.full_messages.flatten.join("<br/>").html_safe
-
     redirect_to(
       edit_shopkeeper_auth_reset_password_path(
         reset_password_token: params[:reset_password_token]
       ),
-      alert: error_messages
+      alert: @resource.errors.full_messages.to_sentence
     )
   end
 end

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -35,7 +35,7 @@ DeviseTokenAuth.setup do |config|
   # Uncomment to enforce current_password param to be checked before all
   # attribute updates. Set it to :password if you want it to be checked only if
   # password is updated.
-  # config.check_current_password_before_update = :attributes
+  config.check_current_password_before_update = :password
 
   # By default we will use callbacks for single omniauth.
   # It depends on fields like email, provider and uid.

--- a/test/controllers/shopkeeper_auth/passwords_controller_test.rb
+++ b/test/controllers/shopkeeper_auth/passwords_controller_test.rb
@@ -35,7 +35,23 @@ class ShopkeeperAuth::PasswordsControllerTest < ActionDispatch::IntegrationTest
     assert_equal 401, JSON.parse(response.body)["code"]
   end
 
-  test "should return not found for non-existent email" do
+  test "should redirect with error when password update fails validation" do
+    token = @shopkeeper.send(:set_reset_password_token)
+
+    patch shopkeeper_password_url,
+      params: {
+        reset_password_token: token,
+        password: "short",
+        password_confirmation: "mismatch"
+      }
+
+    assert_response :redirect
+    assert_match "edit", response.location
+    follow_redirect!
+    assert_select ".bg-yellow-50"
+  end
+
+  test "should return generic success for non-existent email to prevent enumeration" do
     post shopkeeper_password_url,
       params: {
         email: "nonexistent@example.com",
@@ -43,7 +59,7 @@ class ShopkeeperAuth::PasswordsControllerTest < ActionDispatch::IntegrationTest
       },
       as: :json
 
-    assert_response :not_found
-    assert_equal 404, JSON.parse(response.body)["code"]
+    assert_response :ok
+    assert JSON.parse(response.body)["success"]
   end
 end


### PR DESCRIPTION
## Summary
- Remove `.join("<br/>").html_safe` from `render_update_error` in `ShopkeeperAuth::PasswordsController`, use `.to_sentence` instead
- Change `render_not_found_error` to return generic success response, preventing email enumeration
- Enable `check_current_password_before_update = :password` in devise_token_auth config
- Add test for password update validation failure and update non-existent email test

## Test plan
- [x] `bin/rubocop` — no style violations
- [x] `bin/brakeman` — no security warnings
- [x] `bin/rails test` — full test suite passes (338 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)