### PR TITLE
Harden security headers and cleanup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,8 +41,6 @@ gem "image_processing", "~> 1.12"
 # Security update
 gem "nokogiri", ">= 1.12.5"
 
-# Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
-gem "rack-cors"
 gem "devise_token_auth", "~> 1.2", ">= 1.2.2"
 gem "jsonapi-serializer"
 gem "pundit"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -310,9 +310,6 @@ GEM
     rack (3.2.5)
     rack-attack (6.8.0)
       rack (>= 1.0, < 4)
-    rack-cors (3.0.0)
-      logger
-      rack (>= 3.0.14)
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
@@ -513,7 +510,6 @@ DEPENDENCIES
   puma (~> 7.0)
   pundit
   rack-attack
-  rack-cors
   rails (~> 8.1)
   resend
   rubocop-rails-omakase

--- a/app/views/layouts/display.html.erb
+++ b/app/views/layouts/display.html.erb
@@ -18,7 +18,7 @@
     <%# Be sure to add your own custom favicons %>
     <%= render "shared/favicons" %>
 
-    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap">
 
     <%= yield :head %>
   </head>

--- a/app/views/layouts/errors.html.erb
+++ b/app/views/layouts/errors.html.erb
@@ -18,7 +18,7 @@
     <%# Be sure to add your own custom favicons %>
     <%= render "shared/favicons" %>
 
-    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap">
 
     <%= yield :head %>
   </head>

--- a/app/views/layouts/minimal.html.erb
+++ b/app/views/layouts/minimal.html.erb
@@ -18,7 +18,7 @@
     <%# Be sure to add your own custom favicons %>
     <%= render "shared/favicons" %>
 
-    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap">
 
     <%= yield :head %>
   </head>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -79,10 +79,13 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   # Enable DNS rebinding protection and other `Host` header attacks.
-  # config.hosts = [
-  #   "example.com",     # Allow requests from example.com
-  #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
-  # ]
+  # Render automatically sets RENDER_EXTERNAL_HOSTNAME to the service's hostname
+  # (e.g. nativeapptemplateapi.onrender.com). No manual configuration needed.
+  # APP_HOST is for the custom domain (set in Render env vars).
+  config.hosts = [
+    ENV["RENDER_EXTERNAL_HOSTNAME"],
+    ENV["APP_HOST"]
+  ].compact
   # Skip DNS rebinding protection for the default health check endpoint.
-  # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  config.host_authorization = {exclude: ->(request) { request.path == "/up" }}
 end

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -4,26 +4,24 @@
 # See the Securing Rails Applications Guide for more information:
 # https://guides.rubyonrails.org/security.html#content-security-policy-header
 
-# Rails.application.configure do
-#   config.content_security_policy do |policy|
-#     policy.default_src :self, :https
-#     policy.font_src    :self, :https, :data
-#     policy.img_src     :self, :https, :data
-#     policy.object_src  :none
-#     policy.script_src  :self, :https
-#     policy.style_src   :self, :https
-#     # Specify URI for violation reports
-#     # policy.report_uri "/csp-violation-report-endpoint"
-#   end
-#
-#   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
-#   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-#   config.content_security_policy_nonce_directives = %w(script-src style-src)
-#
-#   # Automatically add `nonce` to `javascript_tag`, `javascript_include_tag`, and `stylesheet_link_tag`
-#   # if the corresponding directives are specified in `content_security_policy_nonce_directives`.
-#   # config.content_security_policy_nonce_auto = true
-#
-#   # Report violations without enforcing the policy.
-#   # config.content_security_policy_report_only = true
-# end
+Rails.application.configure do
+  config.content_security_policy do |policy|
+    policy.default_src :self
+    policy.font_src :self, "https://fonts.gstatic.com"
+    policy.img_src :self, :data
+    policy.object_src :none
+    policy.script_src :self
+    policy.style_src :self, :unsafe_inline, "https://fonts.googleapis.com"
+    policy.connect_src :self
+    policy.frame_src :self
+    policy.base_uri :self
+    policy.form_action :self
+  end
+
+  # Generate session nonces for permitted importmap and inline scripts.
+  config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
+  config.content_security_policy_nonce_directives = %w[script-src]
+
+  # Report violations without enforcing the policy.
+  # config.content_security_policy_report_only = true
+end

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -9,7 +9,7 @@ DeviseTokenAuth.setup do |config|
 
   # By default, users will need to re-authenticate after 2 weeks. This setting
   # determines how long tokens will remain valid after they are issued.
-  config.token_lifespan = 90.days
+  config.token_lifespan = 30.days
 
   # Limiting the token_cost to just 4 in testing will increase the performance of
   # your test suite dramatically. The possible cost value is within range from 4
@@ -18,7 +18,7 @@ DeviseTokenAuth.setup do |config|
 
   # Sets the max number of concurrent devices per user, which is 10 by default.
   # After this limit is reached, the oldest tokens will be removed.
-  config.max_number_of_devices = 100
+  config.max_number_of_devices = 10
 
   # Sometimes it's necessary to make several requests to the API at the same
   # time. In this case, each request in the batch will need to share the same

--- a/config/initializers/permissions_policy.rb
+++ b/config/initializers/permissions_policy.rb
@@ -3,11 +3,17 @@
 # Define an application-wide HTTP permissions policy. For further
 # information see: https://developers.google.com/web/updates/2018/06/feature-policy
 
-# Rails.application.config.permissions_policy do |policy|
-#   policy.camera      :none
-#   policy.gyroscope   :none
-#   policy.microphone  :none
-#   policy.usb         :none
-#   policy.fullscreen  :self
-#   policy.payment     :self, "https://secure.example.com"
-# end
+Rails.application.config.permissions_policy do |policy|
+  policy.accelerometer :none
+  policy.ambient_light_sensor :none
+  policy.autoplay :none
+  policy.camera :none
+  policy.geolocation :none
+  policy.gyroscope :none
+  policy.magnetometer :none
+  policy.microphone :none
+  policy.midi :none
+  policy.payment :none
+  policy.usb :none
+  policy.fullscreen :self
+end


### PR DESCRIPTION
## Summary
- Remove unused `rack-cors` gem (not needed for native mobile app API)
- Enable Content-Security-Policy with restrictive defaults, allowing Google Fonts
- Enable Permissions-Policy to disable unnecessary browser features (camera, mic, geolocation, etc.)
- Enable DNS rebinding protection in production using `RENDER_EXTERNAL_HOSTNAME` and `APP_HOST` env vars
- Replace font `preload`/`onload` hack with standard `<link rel="stylesheet">` in all layouts
- Reduce Devise token lifespan from 90 to 30 days
- Reduce max concurrent devices from 100 to 10

## Test plan
- [x] `bin/rubocop` — no offenses
- [x] `bin/brakeman` — no security warnings
- [x] `bin/rails test` — 376 tests, 709 assertions, 0 failures
- [ ] Verify font loading works correctly on web pages (password reset, error pages)
- [ ] Verify API authentication still works with reduced token lifespan/device limits
- [ ] Verify Render deployment succeeds with `RENDER_EXTERNAL_HOSTNAME` and `APP_HOST` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)