### PR TITLE
Fix nil pointer bugs in version lookups and permissions

### DIFF
--- a/app/models/accounts_shopkeeper.rb
+++ b/app/models/accounts_shopkeeper.rb
@@ -17,20 +17,8 @@ class AccountsShopkeeper < ApplicationRecord
   end
 
   def permissions
-    role = if admin?
-      Role.find_by(tag: "admin")
-    elsif senior_manager?
-      Role.find_by(tag: "senior_manager")
-    elsif junior_manager?
-      Role.find_by(tag: "junior_manager")
-    elsif senior_member?
-      Role.find_by(tag: "senior_member")
-    elsif junior_member?
-      Role.find_by(tag: "junior_member")
-    elsif guest?
-      Role.find_by(tag: "guest")
-    end
-
+    role_tag = active_roles.first&.to_s
+    role = Role.find_by!(tag: role_tag)
     role.permissions
   end
 

--- a/app/models/app_version.rb
+++ b/app/models/app_version.rb
@@ -3,11 +3,10 @@ class AppVersion < ApplicationRecord
   enum :forced_update_type, {unforced_update: 1, forced_update: 2}
 
   def self.current_version(platform:)
-    AppVersion
-      .current
+    current
       .where(platform: platform)
       .order(version: :desc)
       .first
-      .version
+      &.version
   end
 end

--- a/app/models/privacy_version.rb
+++ b/app/models/privacy_version.rb
@@ -2,10 +2,9 @@ class PrivacyVersion < ApplicationRecord
   enum :current_type, {uncurrent: 1, current: 2}
 
   def self.current_version
-    PrivacyVersion
-      .current
+    current
       .order(version: :desc)
       .first
-      .version
+      &.version
   end
 end

--- a/app/models/terms_version.rb
+++ b/app/models/terms_version.rb
@@ -2,10 +2,9 @@ class TermsVersion < ApplicationRecord
   enum :current_type, {uncurrent: 1, current: 2}
 
   def self.current_version
-    TermsVersion
-      .current
+    current
       .order(version: :desc)
       .first
-      .version
+      &.version
   end
 end

--- a/test/models/app_version_test.rb
+++ b/test/models/app_version_test.rb
@@ -99,6 +99,20 @@ class AppVersionTest < ActiveSupport::TestCase
     assert_equal 5, AppVersion.current_version(platform: "android")
   end
 
+  test "current_version returns nil for nonexistent platform" do
+    assert_nil AppVersion.current_version(platform: "nonexistent")
+  end
+
+  test "current_version respects chained scopes" do
+    version = AppVersion.forced_update.current_version(platform: "ios")
+    assert_not_nil version
+
+    # unforced_update scope should not find forced_update records
+    AppVersion.where(platform: "ios").update_all(forced_update_type: :forced_update)
+    version = AppVersion.unforced_update.current_version(platform: "ios")
+    assert_nil version
+  end
+
   test "should load from fixtures" do
     assert AppVersion.count > 0
 

--- a/test/models/privacy_version_test.rb
+++ b/test/models/privacy_version_test.rb
@@ -73,6 +73,11 @@ class PrivacyVersionTest < ActiveSupport::TestCase
     assert_equal 5, PrivacyVersion.current_version
   end
 
+  test "current_version returns nil when no current version exists" do
+    PrivacyVersion.update_all(current_type: :uncurrent)
+    assert_nil PrivacyVersion.current_version
+  end
+
   test "should load from fixtures" do
     assert PrivacyVersion.count > 0
 

--- a/test/models/terms_version_test.rb
+++ b/test/models/terms_version_test.rb
@@ -73,6 +73,11 @@ class TermsVersionTest < ActiveSupport::TestCase
     assert_equal 5, TermsVersion.current_version
   end
 
+  test "current_version returns nil when no current version exists" do
+    TermsVersion.update_all(current_type: :uncurrent)
+    assert_nil TermsVersion.current_version
+  end
+
   test "should load from fixtures" do
     assert TermsVersion.count > 0
 


### PR DESCRIPTION
## Summary
- Fix `AppVersion.current_version`, `PrivacyVersion.current_version`, `TermsVersion.current_version` — `.first.version` crashes with `NoMethodError` when no matching record exists. Use `&.version` for nil safety.
- Fix `AppVersion.current_version` scope chaining — `AppVersion.current` started a new query chain, losing any previously chained scopes (e.g. `forced_update`). Changed to `current` (relative) so chained scopes are preserved.
- Simplify `AccountsShopkeeper#permissions` — replace 12-line if/elsif chain with `active_roles.first` + `find_by!` for clearer code and better error on missing role data.

## Test plan
- [x] All 405 tests pass (803 assertions, 0 failures)
- [x] New tests for nil-safety: `current_version` returns nil when no records match
- [x] New test for scope chaining: `unforced_update.current_version` respects chained scope
- [x] Existing permission tests (6 roles) pass with refactored `permissions` method
- [x] RuboCop clean, Brakeman clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)