### PR TITLE
Remove dead code: unused methods, scopes, and tests

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -14,19 +14,11 @@ class Account < ApplicationRecord
 
   after_create :create_default_shop!
 
-  def personal_account_for?(shopkeeper)
-    personal? && owner?(shopkeeper)
-  end
-
   def admin?(shopkeeper)
     accounts_shopkeeper = AccountsShopkeeper.find_by(account: self, shopkeeper: shopkeeper)
     return false if accounts_shopkeeper.blank?
 
     accounts_shopkeeper.admin?
-  end
-
-  def owner?(user)
-    owner_id == user.id
   end
 
   private

--- a/app/models/accounts_invitation.rb
+++ b/app/models/accounts_invitation.rb
@@ -12,9 +12,6 @@ class AccountsInvitation < ApplicationRecord
 
   before_create :set_token
 
-  scope :active, -> { where(created_at: EXPIRES_IN.ago..) }
-  scope :expired, -> { where(created_at: ...EXPIRES_IN.ago) }
-
   def expired?
     created_at < EXPIRES_IN.ago
   end

--- a/app/models/shopkeeper.rb
+++ b/app/models/shopkeeper.rb
@@ -25,9 +25,6 @@ class Shopkeeper < ApplicationRecord
     presence: true,
     inclusion: {in: %w[ios android]}
 
-  scope :android, -> { where(current_platform: "android") }
-  scope :ios, -> { where(current_platform: "ios") }
-
   # override devise method to include additional info as opts hash
   def send_confirmation_instructions(opts = {})
     generate_confirmation_token! unless @raw_confirmation_token

--- a/test/models/account_test.rb
+++ b/test/models/account_test.rb
@@ -43,27 +43,6 @@ class AccountTest < ActiveSupport::TestCase
     assert_not_includes Account.team, personal_account
   end
 
-  test "personal_account_for? returns true for owner's personal account" do
-    account = Account.create!(name: "Personal", owner: @shopkeeper, personal: true)
-    assert account.personal_account_for?(@shopkeeper)
-  end
-
-  test "personal_account_for? returns false for team account" do
-    account = Account.create!(name: "Team", owner: @shopkeeper, personal: false)
-    assert_not account.personal_account_for?(@shopkeeper)
-  end
-
-  test "owner? returns true for account owner" do
-    account = Account.create!(name: "Test Account", owner: @shopkeeper)
-    assert account.owner?(@shopkeeper)
-  end
-
-  test "owner? returns false for non-owner" do
-    other_shopkeeper = shopkeepers(:two)
-    account = Account.create!(name: "Test Account", owner: @shopkeeper)
-    assert_not account.owner?(other_shopkeeper)
-  end
-
   test "admin? returns true when shopkeeper is admin" do
     account = Account.create!(name: "Test Account", owner: @shopkeeper)
     AccountsShopkeeper.create!(

--- a/test/models/accounts_invitation_test.rb
+++ b/test/models/accounts_invitation_test.rb
@@ -299,27 +299,6 @@ class AccountsInvitationTest < ActiveSupport::TestCase
     end
   end
 
-  test "active scope returns non-expired invitations" do
-    active_invitation = AccountsInvitation.create!(
-      account: @account,
-      name: "Active User",
-      email: "active_scope@example.com",
-      junior_member: true
-    )
-
-    expired_invitation = AccountsInvitation.create!(
-      account: @account,
-      name: "Expired User",
-      email: "expired_scope@example.com",
-      junior_member: true
-    )
-    expired_invitation.update_column(:created_at, (AccountsInvitation::EXPIRES_IN + 1.minute).ago)
-
-    active_invitations = AccountsInvitation.active
-    assert_includes active_invitations, active_invitation
-    assert_not_includes active_invitations, expired_invitation
-  end
-
   test "resend_invite touches created_at and sends invite" do
     invitation = AccountsInvitation.create!(
       account: @account,

--- a/test/models/shopkeeper_test.rb
+++ b/test/models/shopkeeper_test.rb
@@ -66,20 +66,6 @@ class ShopkeeperTest < ActiveSupport::TestCase
     assert shopkeeper.valid?
   end
 
-  test "android scope returns android shopkeepers" do
-    shopkeeper = shopkeepers(:one)
-    shopkeeper.update!(current_platform: "android")
-
-    assert_includes Shopkeeper.android, shopkeeper
-  end
-
-  test "ios scope returns ios shopkeepers" do
-    shopkeeper = shopkeepers(:one)
-    shopkeeper.update!(current_platform: "ios")
-
-    assert_includes Shopkeeper.ios, shopkeeper
-  end
-
   test "should have many shops through accounts" do
     shopkeeper = shopkeepers(:one)
     shopkeeper.create_default_account


### PR DESCRIPTION
## Summary
- Remove `Account#personal_account_for?` and `Account#owner?` — never called in production code
- Remove `Shopkeeper` `.android`/`.ios` scopes — never used in app
- Remove `AccountsInvitation` `.active`/`.expired` scopes — only the instance method `expired?` is used
- Remove corresponding dead tests (7 tests)

## Test plan
- [x] All 398 tests pass (791 assertions, 0 failures)
- [x] RuboCop clean
- [x] Brakeman clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)