### PR TITLE
add API documentation link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ A [Rails 8.1](https://rubyonrails.org/) API backend for NativeAppTemplate iOS/An
 
 For more information, visit [nativeapptemplate.com](https://nativeapptemplate.com).
 
+## API Documentation
+
+[API Documentation](https://nativeapptemplate.com/api-docs/index.html)
+
 ## Related Repositories
 
 ### Paid Clients


### PR DESCRIPTION
## Summary
- Add API Documentation section with link to https://nativeapptemplate.com/api-docs/index.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)