### PR TITLE
Refactor: small cleanups across models and controllers

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,17 +1,19 @@
 class ErrorsController < NonApiApplicationController
   def not_found
-    if request.content_type&.include?("application/json")
-      render json: {code: 404, error_message: "Not found."}, status: 404
-    else
-      render status: 404
-    end
+    render_error(404, "Not found.")
   end
 
   def internal_server_error
+    render_error(500, "Internal server error.")
+  end
+
+  private
+
+  def render_error(status, message)
     if request.content_type&.include?("application/json")
-      render json: {code: 500, error_message: "Internal server error."}, status: 500
+      render json: {code: status, error_message: message}, status: status
     else
-      render status: 500
+      render status: status
     end
   end
 end

--- a/app/controllers/shopkeeper_auth/registrations_controller.rb
+++ b/app/controllers/shopkeeper_auth/registrations_controller.rb
@@ -33,18 +33,22 @@ class ShopkeeperAuth::RegistrationsController < DeviseTokenAuth::RegistrationsCo
   end
 
   def render_create_error
-    render json: {code: 422, error_message: @resource.errors.full_messages.to_sentence}, status: :unprocessable_entity
+    render_resource_error
   end
 
   def render_update_error
-    render json: {code: 422, error_message: @resource.errors.full_messages.to_sentence}, status: :unprocessable_entity
+    render_resource_error
   end
 
   def render_destroy_error
-    render json: {code: 422, error_message: @resource.errors.full_messages.to_sentence}, status: :unprocessable_entity
+    render_resource_error
   end
 
   private
+
+  def render_resource_error
+    render json: {code: 422, error_message: @resource.errors.full_messages.to_sentence}, status: :unprocessable_entity
+  end
 
   def validate_sign_up_params
     return if sign_up_params.present?

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -43,9 +43,9 @@ class Account < ApplicationRecord
   end
 
   def limit_count
-    the_limit_count = ConfigSettings.account.limit_count
-    return if owner.owned_accounts.count < the_limit_count
+    limit = ConfigSettings.account.limit_count
+    return if owner.owned_accounts.count < limit
 
-    errors.add :base, :limit_count_account, limit_count: the_limit_count
+    errors.add :base, :limit_count_account, limit_count: limit
   end
 end

--- a/app/models/accounts_invitation.rb
+++ b/app/models/accounts_invitation.rb
@@ -55,14 +55,10 @@ class AccountsInvitation < ApplicationRecord
   private
 
   def set_token
-    the_token = nil
-
-    loop do
-      the_token = random_token
-      break unless AccountsInvitation.exists?(token: the_token)
+    self.token = loop do
+      candidate = random_token
+      break candidate unless AccountsInvitation.exists?(token: candidate)
     end
-
-    self.token = the_token
   end
 
   def random_token

--- a/app/models/accounts_shopkeeper.rb
+++ b/app/models/accounts_shopkeeper.rb
@@ -31,9 +31,9 @@ class AccountsShopkeeper < ApplicationRecord
   end
 
   def limit_count
-    the_limit_count = ConfigSettings.accounts_shopkeeper.limit_count
-    return if account.accounts_shopkeepers.count < the_limit_count
+    limit = ConfigSettings.accounts_shopkeeper.limit_count
+    return if account.accounts_shopkeepers.count < limit
 
-    errors.add :base, :limit_count_accounts_shopkeeper, limit_count: the_limit_count
+    errors.add :base, :limit_count_accounts_shopkeeper, limit_count: limit
   end
 end

--- a/app/models/item_tag.rb
+++ b/app/models/item_tag.rb
@@ -36,9 +36,9 @@ class ItemTag < ApplicationRecord
   end
 
   def limit_count
-    the_limit_count = ConfigSettings.item_tag.limit_count
-    return if shop.item_tags.count < the_limit_count
+    limit = ConfigSettings.item_tag.limit_count
+    return if shop.item_tags.count < limit
 
-    errors.add :base, :limit_count_item_tag, limit_count: the_limit_count
+    errors.add :base, :limit_count_item_tag, limit_count: limit
   end
 end

--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -26,10 +26,10 @@ class Shop < ApplicationRecord
 
   def limit_count
     ActsAsTenant.without_tenant do
-      the_limit_count = ConfigSettings.shop.limit_count
-      return if created_by.created_shops.count < the_limit_count
+      limit = ConfigSettings.shop.limit_count
+      return if created_by.created_shops.count < limit
 
-      errors.add :base, :limit_count_shop, limit_count: the_limit_count
+      errors.add :base, :limit_count_shop, limit_count: limit
     end
   end
 end

--- a/app/models/shopkeeper.rb
+++ b/app/models/shopkeeper.rb
@@ -34,7 +34,6 @@ class Shopkeeper < ApplicationRecord
     opts[:to] = unconfirmed_email if pending_reconfirmation?
     opts[:redirect_url] ||= DeviseTokenAuth.default_confirm_success_url
 
-    # send_devise_notification(:confirmation_instructions, @raw_confirmation_token, opts)
     Shopkeeper::NotificationMailer.with(resource: self, token: @raw_confirmation_token, opts: opts).confirmation_instructions.deliver_later
   end
 
@@ -45,7 +44,6 @@ class Shopkeeper < ApplicationRecord
     # fall back to "default" config name
     opts[:client_config] ||= "default"
 
-    # send_devise_notification(:reset_password_instructions, token, opts)
     Shopkeeper::NotificationMailer.with(resource: self, token: token, opts: opts).reset_password_instructions.deliver_later
 
     token


### PR DESCRIPTION
## Summary
- `ErrorsController`: extract shared `render_error` helper to remove the duplicated JSON/HTML branching across `not_found` and `internal_server_error`.
- `ShopkeeperAuth::RegistrationsController`: the three identical `render_create_error`/`render_update_error`/`render_destroy_error` hooks now delegate to a single private `render_resource_error`.
- `Account`/`Shop`/`ItemTag`/`AccountsShopkeeper`: rename the `the_limit_count` local in each `limit_count` validator to plain `limit`.
- `AccountsInvitation#set_token`: collapse the unique-token loop using `break candidate` as the assignment value.
- `Shopkeeper`: drop two commented-out `send_devise_notification` lines that were superseded by the custom mailer.

All changes are behavior-preserving — no logic, error keys, return values, or method signatures changed.

## Test plan
- [x] `bin/rails test` passes (393 runs, 792 assertions, 0 failures)
- [x] `bin/rubocop` clean on touched files
- [x] `bin/brakeman` clean (0 warnings)
- [x] CI passes on the PR branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)