### PR TITLE
Rate-limit shopkeeper sign-up to 10/IP/3min

### DIFF
--- a/app/controllers/shopkeeper_auth/registrations_controller.rb
+++ b/app/controllers/shopkeeper_auth/registrations_controller.rb
@@ -1,5 +1,5 @@
 class ShopkeeperAuth::RegistrationsController < DeviseTokenAuth::RegistrationsController
-  rate_limit to: 5, within: 1.hour, only: :create,
+  rate_limit to: 10, within: 3.minutes, only: :create,
     with: -> {
       render json: {code: 429, error_message: I18n.t("errors.messages.too_many_signups")},
         status: :too_many_requests

--- a/app/controllers/shopkeeper_auth/registrations_controller.rb
+++ b/app/controllers/shopkeeper_auth/registrations_controller.rb
@@ -1,4 +1,10 @@
 class ShopkeeperAuth::RegistrationsController < DeviseTokenAuth::RegistrationsController
+  rate_limit to: 5, within: 1.hour, only: :create,
+    with: -> {
+      render json: {code: 429, error_message: I18n.t("errors.messages.too_many_signups")},
+        status: :too_many_requests
+    }
+
   before_action :set_confirm_success_url, only: %i[create]
   before_action :configure_permitted_parameters
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -22,7 +22,9 @@ Rails.application.configure do
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local = true
-  config.cache_store = :null_store
+  # Use memory store so ActionController::RateLimiting can persist counters
+  # between requests within a test; null_store would no-op the increments.
+  config.cache_store = :memory_store
 
   # Render exception templates for rescuable exceptions and raise for other exceptions.
   config.action_dispatch.show_exceptions = :rescuable

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -142,3 +142,4 @@ en:
       limit_count_shop: "You can create up to %{limit_count} shops across all organizations."
       limit_count_accounts_shopkeeper: "Organization members can be created up to %{limit_count}. Please contact the organization admin user or owner."
       limit_count_item_tag: "You can create up to %{limit_count} item tags."
+      too_many_signups: "Too many sign-up attempts. Please try again later."

--- a/test/integration/sign_up_throttle_test.rb
+++ b/test/integration/sign_up_throttle_test.rb
@@ -14,13 +14,13 @@ class SignUpThrottleTest < ActionDispatch::IntegrationTest
       as: :json
   end
 
-  test "the sixth sign-up from the same IP within an hour is rate-limited" do
-    5.times do |i|
+  test "the eleventh sign-up from the same IP within the window is rate-limited" do
+    10.times do |i|
       post_sign_up("throttle#{i}@example.com")
       assert_not_equal 429, response.status, "request #{i + 1} should not be throttled"
     end
 
-    post_sign_up("throttle5@example.com")
+    post_sign_up("throttle10@example.com")
 
     assert_response :too_many_requests
     assert_equal 429, response.parsed_body["code"]

--- a/test/integration/sign_up_throttle_test.rb
+++ b/test/integration/sign_up_throttle_test.rb
@@ -1,0 +1,29 @@
+require "test_helper"
+
+class SignUpThrottleTest < ActionDispatch::IntegrationTest
+  def post_sign_up(email)
+    post shopkeeper_registration_url,
+      params: {
+        name: "Throttle Test",
+        email: email,
+        password: "password",
+        password_confirmation: "password",
+        time_zone: "Tokyo",
+        current_platform: "ios"
+      },
+      as: :json
+  end
+
+  test "the sixth sign-up from the same IP within an hour is rate-limited" do
+    5.times do |i|
+      post_sign_up("throttle#{i}@example.com")
+      assert_not_equal 429, response.status, "request #{i + 1} should not be throttled"
+    end
+
+    post_sign_up("throttle5@example.com")
+
+    assert_response :too_many_requests
+    assert_equal 429, response.parsed_body["code"]
+    assert_equal I18n.t("errors.messages.too_many_signups"), response.parsed_body["error_message"]
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,6 +14,7 @@ module ActiveSupport
   class TestCase
     setup do
       Dir[Rails.root.join("db", "fixtures", "test", "*.rb")].sort.each { |s| load s }
+      Rails.cache.clear
     end
 
     # Run tests in parallel with specified workers


### PR DESCRIPTION
## Summary

Adds an endpoint-specific rate limit on `POST /shopkeeper_auth` (sign-up) using Rails 8's built-in `ActionController::RateLimiting` — 10 requests per IP per 3 minutes (matches the jumpstart-pro-rails reference). The 11th attempt within the window returns `429 Too Many Requests` with a localized JSON error.

Mass account creation was previously only constrained by the broad 300/IP/5min `req/ip` cap in `config/initializers/rack_attack.rb`. Sign-in already has dedicated `logins/ip` and `logins/email` throttles in rack-attack; sign-up did not.

## Why `rate_limit` instead of a new rack-attack throttle

- **Rails-native, available in Rails 8.x** (this app is on 8.1).
- The rule lives next to the action it guards (`RegistrationsController`), no separate config indirection.
- Same pattern used in jumpstart-pro-rails' `RegistrationsController`.
- Defaults to `Rails.cache` for storage; in production this app uses Solid Cache, so the limit holds across Puma workers.

## Changes

- `app/controllers/shopkeeper_auth/registrations_controller.rb` — add `rate_limit to: 10, within: 3.minutes, only: :create, with: -> { render json: ... }`.
- `config/locales/en.yml` — add `errors.messages.too_many_signups`.
- `config/environments/test.rb` — switch `cache_store` from `:null_store` to `:memory_store`. `:null_store` no-ops the rate-limiter's `increment` calls, so the limit cannot be exercised in tests.
- `test/test_helper.rb` — `Rails.cache.clear` in the standard `setup` block so throttle counters don't leak between tests.
- `test/integration/sign_up_throttle_test.rb` — new: 10 sign-ups succeed, 11th returns 429 with the expected message.

## Test plan
- [x] `bin/rails test test/integration/sign_up_throttle_test.rb` (1 run, 13 assertions, 0 failures)
- [x] `bin/rails test` full suite (394 runs, 805 assertions, 0 failures) — confirms `:memory_store` swap doesn't regress anything
- [x] `bin/rubocop` clean on touched files
- [x] `bin/brakeman` clean (0 warnings)
- [ ] CI passes on the PR branch

## Out of scope
- Devise `:lockable` (defense-in-depth on sign-in; separate decision).
- Moving the existing rack-attack login throttles into `SessionsController` with `rate_limit` (consolidation; behavior unchanged today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
