### PR TITLE
Remove dead code: unused gems and locale keys

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,9 +20,6 @@ gem "turbo-rails", "~> 2.0.3"
 # Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]
 gem "stimulus-rails", "~> 1.0", ">= 1.0.2"
 
-# Build JSON APIs with ease [https://github.com/rails/jbuilder]
-gem "jbuilder", "~> 2.14"
-
 # Solid adapters for queue, cache, and cable (database-backed, no Redis needed)
 gem "solid_queue"
 gem "solid_cable"
@@ -49,7 +46,6 @@ gem "aasm"
 gem "after_commit_everywhere", "~> 1.6"
 gem "config"
 gem "acts_as_tenant"
-gem "inline_svg", "~> 1.10"
 gem "pagy", "~> 43"
 gem "seed-fu", "~> 2.3"
 gem "whenever", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,18 +179,12 @@ GEM
       activesupport (>= 6.0.0)
       railties (>= 6.0.0)
     iniparse (1.5.0)
-    inline_svg (1.10.0)
-      activesupport (>= 3.0)
-      nokogiri (>= 1.6)
     io-console (0.8.2)
     irb (1.17.0)
       pp (>= 0.6.0)
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    jbuilder (2.14.1)
-      actionview (>= 7.0.0)
-      activesupport (>= 7.0.0)
     json (2.19.3)
     json-schema (6.2.0)
       addressable (~> 2.8)
@@ -494,8 +488,6 @@ DEPENDENCIES
   erb_lint
   image_processing (~> 1.12)
   importmap-rails
-  inline_svg (~> 1.10)
-  jbuilder (~> 2.14)
   jsonapi-serializer
   madmin (~> 2.0)
   mailbin

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,8 +32,6 @@
 en:
   hello: "hello"
   welcome: "welcome"
-  forgot_your_password: "Forgot your password?"
-  send_me_reset_password_instructions: "Send me reset password instructions"
   change_my_password: "Change my password"
   change_your_password: "Change your password"
   confirm_new_password: "Confirm new password"
@@ -45,8 +43,6 @@ en:
   api:
     shopkeeper:
       accounts:
-        owner_required: "Only account owner is allowed to do that."
-        admin_required: "Only account admins are allowed to do that."
         personal:
           cannot_delete: "You cannot delete your personal account."
       accounts_invitations:


### PR DESCRIPTION
## Summary

Removes verified-unreferenced gems and locale keys. Every removal was confirmed with a `grep -rn` across `app/`, `lib/`, `config/` (and the gem source for the locale keys) that found no usage outside the definition site.

## Removed

**Gems**
- `jbuilder ~> 2.14` — no `.jbuilder` view files exist; all responses go through `jsonapi-serializer`. Adds 1 transitive dep gone.
- `inline_svg ~> 1.10` — no `inline_svg` helper calls anywhere in `app/views/` or controllers.

**Locale keys**
- `forgot_your_password`
- `send_me_reset_password_instructions`
- `api.shopkeeper.accounts.owner_required`
- `api.shopkeeper.accounts.admin_required`

## Considered and kept

- `validate_sign_up_params` / `validate_account_update_params` overrides in `ShopkeeperAuth::RegistrationsController` — initially looked dead (the subclass declares them but never calls them). Verified in the `devise_token_auth` 1.2.6 source: the parent class wires both as `before_action` on `:create` / `:update`, so the overrides DO get called when validation fails. Kept.
- Other unused-looking locale keys (`hello`, `welcome`, `change_my_password`, `change_your_password`, `confirm_new_password`, `new_password`) — `welcome`/`hello` and the password form keys are referenced in views and mailer templates. Kept.

## Test plan
- [x] `bin/rails test` (398 runs, 815 assertions, 0 failures)
- [x] `bin/rubocop` clean (227 files, 0 offenses)
- [x] `bundle exec erb_lint --lint-all` clean (14 files, 0 errors)
- [x] `bin/brakeman` clean (0 warnings)
- [x] `bundle install` cleanly removes both gems from `Gemfile.lock`
- [ ] CI passes on the PR branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
