### PR TITLE
Normalize NATEMPLATE_API_DOMAIN docs to NATIVEAPPTEMPLATE_API_DOMAIN

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -8,8 +8,8 @@
 #
 # Never use 127.0.0.1, localhost, or 0.0.0.0. When your Wi-Fi IP
 # changes, update HOST here and the matching values in the mobile
-# apps (Xcode scheme NATEMPLATE_API_DOMAIN and Android
-# ~/.gradle/gradle.properties NATEMPLATE_API_DOMAIN).
+# apps (Xcode scheme NATIVEAPPTEMPLATE_API_DOMAIN and Android
+# ~/.gradle/gradle.properties NATIVEAPPTEMPLATE_API_DOMAIN).
 
 HOST=192.168.1.21
 PORT=3000

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,7 @@ bin/rails dbconsole           # Database console
 - Run tests: `bin/rails test` (205 tests, 402 assertions)
 
 ### Development Server Configuration
-- `HOST` (Wi-Fi IP) and `PORT` are required in `.env`; `Procfile.dev` uses `${HOST:?...}` so Rails fails loudly if unset, and `development.rb` uses `ENV.fetch("HOST")` for `action_mailer.default_url_options`. Must match `NATEMPLATE_API_DOMAIN` in the iOS scheme and Android `gradle.properties`. Never `127.0.0.1`, `localhost`, or `0.0.0.0`.
+- `HOST` (Wi-Fi IP) and `PORT` are required in `.env`; `Procfile.dev` uses `${HOST:?...}` so Rails fails loudly if unset, and `development.rb` uses `ENV.fetch("HOST")` for `action_mailer.default_url_options`. Must match `NATIVEAPPTEMPLATE_API_DOMAIN` in the iOS scheme and Android `gradle.properties`. Never `127.0.0.1`, `localhost`, or `0.0.0.0`.
 - Mailbin for email testing at `/mailbin`
 - Admin interface at `/madmin`
 - Tailwind CSS compiled by tailwindcss-rails gem

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ bin/setup
 
 ## Running NativeAppTemplate API on your Wi-Fi
 
-Copy `.env.sample` to `.env` and set `HOST` to your current Wi-Fi IP. On macOS: `ipconfig getifaddr en0`. `bin/dev` binds Rails to that address so the dev server is reachable from both the host browser and from any phone on the same network at `http://<wifi-ip>:3000`. When your Wi-Fi IP changes, update `HOST` here and the matching `NATEMPLATE_API_DOMAIN` in the mobile apps (Xcode scheme for iOS, `~/.gradle/gradle.properties` for Android) — Rails fails loudly if `HOST` is unset, which keeps the three sides honest. Never use `127.0.0.1`, `localhost`, or `0.0.0.0`.
+Copy `.env.sample` to `.env` and set `HOST` to your current Wi-Fi IP. On macOS: `ipconfig getifaddr en0`. `bin/dev` binds Rails to that address so the dev server is reachable from both the host browser and from any phone on the same network at `http://<wifi-ip>:3000`. When your Wi-Fi IP changes, update `HOST` here and the matching `NATIVEAPPTEMPLATE_API_DOMAIN` in the mobile apps (Xcode scheme for iOS, `~/.gradle/gradle.properties` for Android) — Rails fails loudly if `HOST` is unset, which keeps the three sides honest. Never use `127.0.0.1`, `localhost`, or `0.0.0.0`.
 
 To run your application, you'll use the `bin/dev` command:
 


### PR DESCRIPTION
## Summary
- Per `docs-private/SUBSTRATE-NAMING-NORMALIZATION.md`, the three substrates (Rails / iOS / Android) should all use the canonical `NATIVEAPPTEMPLATE_` stem so the agent's existing `NativeAppTemplate → <slug-pascal>` rename pair handles every product-name occurrence (no per-substrate special-cases in the agent).
- The Rails repo has no boot/config references to these env vars — only three doc references (`README.md`, `CLAUDE.md`, `.env.sample`) that point users at the iOS/Android counterparts. Renamed those for parity.
- Substrate-side Kotlin/Swift symbol renames, theme renames, and error-code prefix changes from the plan are out of scope for this repo (handled in the iOS/Android substrates).

## Verification
- `rg -n "NATEMPLATE|Nat[A-Z]|NATA-|NATI-"` (excluding `.git/` and the plan doc itself) returns no matches.
- `bin/rubocop` — no offenses
- `bin/rails test` — 398 runs, 815 assertions, 0 failures, 0 errors, 0 skips

## Test plan
- [x] `bin/rubocop`
- [x] `bin/rails test`
- [ ] iOS / Android substrate PRs land matching `NATIVEAPPTEMPLATE_API_*` env-var renames so the three sides agree

🤖 Generated with [Claude Code](https://claude.com/claude-code)