### PR TITLE
Drop articles before domain nouns for rename safety

### DIFF
--- a/docs/nativeapptemplate-substrate-v2-overview.md
+++ b/docs/nativeapptemplate-substrate-v2-overview.md
@@ -140,7 +140,7 @@ See section 6.10 for rationale on the unified permission approach.
 
 **Endpoints unchanged but with behavior change**:
 - `POST /api/v1/shopkeeper/shops/:shop_id/item_tags` — no longer auto-generates A001-A010; creates a single item with user-supplied `name`
-- `POST /api/v1/shopkeeper/shops` — creating a Shop now auto-generates exactly 1 "Sample" ItemTag (instead of 10 queue-number items), so new users see a reference item on the Shop detail screen instead of an empty state
+- `POST /api/v1/shopkeeper/shops` — creating Shop now auto-generates exactly 1 "Sample" ItemTag (instead of 10 queue-number items), so new users see a reference item on Shop detail screen instead of an empty state
 
 ### 2.3 UI contract
 
@@ -489,7 +489,7 @@ The Rails API uses a custom fixture system in `db/fixtures/<env>/` (not standard
 
 ### 8.3 What to avoid
 
-- Do NOT resurrect the Day 1 approach of fully deleting `ItemTag`. The Shop detail screen becomes empty without a child resource, and the agent's planner prompt assumes `ItemTag` exists as a rename target.
+- Do NOT resurrect the Day 1 approach of fully deleting `ItemTag`. Shop detail screen becomes empty without a child resource, and the agent's planner prompt assumes `ItemTag` exists as a rename target.
 - Do NOT introduce a new child model name (e.g. `ShopItem`). Keeping `ItemTag` aligns with the agent's planner prompt.
 - Do NOT add i18n / Localizable.strings indirection in Phase 2-5. UI strings should be direct literals so the agent's string-literal rename (Phase 6) can operate on them.
 - Do NOT touch the `AccountsInvitation` model or multi-account join table. Those stay; Free client just hides their UI.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -799,7 +799,7 @@ paths:
   /shopkeeper_auth/sign_in:
     post:
       operationId: signIn
-      summary: Sign in a shopkeeper
+      summary: Sign in shopkeeper
       tags: [Auth - Sessions]
       security: []
       servers:
@@ -857,7 +857,7 @@ paths:
   /shopkeeper_auth/sign_out:
     delete:
       operationId: signOut
-      summary: Sign out a shopkeeper
+      summary: Sign out shopkeeper
       tags: [Auth - Sessions]
       servers:
         - url: /
@@ -1148,7 +1148,7 @@ paths:
 
     get:
       operationId: getShop
-      summary: Get a shop
+      summary: Get shop
       tags: [Shops]
       responses:
         '200':
@@ -1165,7 +1165,7 @@ paths:
 
     patch:
       operationId: updateShop
-      summary: Update a shop
+      summary: Update shop
       tags: [Shops]
       requestBody:
         required: true
@@ -1190,7 +1190,7 @@ paths:
 
     delete:
       operationId: deleteShop
-      summary: Delete a shop
+      summary: Delete shop
       tags: [Shops]
       responses:
         '200':
@@ -1214,7 +1214,7 @@ paths:
 
     get:
       operationId: listItemTags
-      summary: List item tags for a shop
+      summary: List item tags for shop
       tags: [Item Tags]
       parameters:
         - name: page
@@ -1256,7 +1256,7 @@ paths:
 
     post:
       operationId: createItemTag
-      summary: Create an item tag in a shop
+      summary: Create item tag in shop
       tags: [Item Tags]
       requestBody:
         required: true
@@ -1290,7 +1290,7 @@ paths:
 
     get:
       operationId: getItemTag
-      summary: Get an item tag
+      summary: Get item tag
       tags: [Item Tags]
       responses:
         '200':
@@ -1309,7 +1309,7 @@ paths:
 
     patch:
       operationId: updateItemTag
-      summary: Update an item tag
+      summary: Update item tag
       tags: [Item Tags]
       requestBody:
         required: true
@@ -1336,7 +1336,7 @@ paths:
 
     delete:
       operationId: deleteItemTag
-      summary: Delete an item tag
+      summary: Delete item tag
       tags: [Item Tags]
       responses:
         '200':
@@ -1361,7 +1361,7 @@ paths:
 
     patch:
       operationId: completeItemTag
-      summary: Mark an item tag as completed
+      summary: Mark item tag as completed
       tags: [Item Tags]
       responses:
         '200':
@@ -1393,7 +1393,7 @@ paths:
 
     patch:
       operationId: idleItemTag
-      summary: Reset an item tag to idled state
+      summary: Reset item tag to idled state
       tags: [Item Tags]
       responses:
         '200':

--- a/docs/phase1-rails-api.md
+++ b/docs/phase1-rails-api.md
@@ -378,7 +378,7 @@ class Shop < ApplicationRecord
 end
 ```
 
-**Rationale for sample item**: When a Shop is first created, the Shop detail screen would otherwise be empty. A single generic "Sample" item gives users a reference to understand the UI and something to delete/edit to learn the flow. The client-side empty state UI (already implemented) handles the case after the sample is deleted.
+**Rationale for sample item**: When Shop is first created, Shop detail screen would otherwise be empty. A single generic "Sample" item gives users a reference to understand the UI and something to delete/edit to learn the flow. The client-side empty state UI (already implemented) handles the case after the sample is deleted.
 
 Check callers of removed methods:
 
@@ -406,7 +406,7 @@ git commit -m "Simplify Shop model: replace queue auto-generation with single sa
 - Filter on `queue_number`, `scan_state`, etc.
 
 **Ensure standard CRUD actions work**:
-- `index` — list item_tags for a shop
+- `index` — list item_tags for shop
 - `show` — single item_tag
 - `create` — requires `name`, accepts optional `description`, `position`
 - `update` — modify `name`, `description`, `position`, `state`
@@ -757,7 +757,7 @@ end
 - Update fixture data references (`queue_number` → `name`)
 - Remove tests for removed endpoints (scan, reset_all)
 - Add tests for `description`, `position` handling
-- Note: tests that create a Shop will now also create a sample ItemTag via the callback. Adjust `assert_difference` expectations: creating a Shop now creates 1 Shop + 1 ItemTag.
+- Note: tests that create Shop will now also create a sample ItemTag via the callback. Adjust `assert_difference` expectations: creating Shop now creates 1 Shop + 1 ItemTag.
 
 **`test/policies/api/shopkeeper/item_tag_policy_test.rb`**:
 - Remove tests for deleted permission tags
@@ -912,7 +912,7 @@ Expected: all green, 0 failures, 0 errors. Test count will be lower than baselin
 bin/rails server -d
 
 # Create a test shopkeeper and shop, then verify:
-# - Creating a shop creates exactly 1 "Sample" item_tag automatically
+# - Creating shop creates exactly 1 "Sample" item_tag automatically
 # - The sample item_tag has state: "idled"
 # - Manual CRUD on item_tags works
 
@@ -1002,7 +1002,7 @@ Early, to catch fixture association breakage.
 
 ### 6. Sample item_tag and test isolation
 
-After the refactor, creating a Shop in tests auto-creates 1 ItemTag via `create_sample_item_tag`. Tests that count ItemTags must account for this:
+After the refactor, creating Shop in tests auto-creates 1 ItemTag via `create_sample_item_tag`. Tests that count ItemTags must account for this:
 
 ```ruby
 # Before: 0 item_tags after shop creation

--- a/test/controllers/api/v1/shopkeeper/base_controller_test.rb
+++ b/test/controllers/api/v1/shopkeeper/base_controller_test.rb
@@ -9,7 +9,7 @@ class Api::V1::Shopkeeper::BaseControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "render_validation_error returns 422 with error messages" do
-    # Try to create an item_tag with a blank name to trigger validation error
+    # Try to create item_tag with a blank name to trigger validation error
     post api_v1_shopkeeper_shop_item_tags_url(@shop),
       params: {item_tag: {name: ""}},
       headers: @shopkeeper.create_new_auth_token

--- a/test/controllers/api/v1/shopkeeper/item_tags_controller_test.rb
+++ b/test/controllers/api/v1/shopkeeper/item_tags_controller_test.rb
@@ -61,7 +61,7 @@ class Api::V1::Shopkeeper::ItemTagsControllerTest < ActionDispatch::IntegrationT
   end
 
   # show
-  test "show returns an item_tag detail" do
+  test "show returns item_tag detail" do
     get api_v1_shopkeeper_item_tag_url(@item_tag), headers: @shopkeeper.create_new_auth_token
     assert_response :success
     assert_equal response.parsed_body["data"]["attributes"]["name"], @item_tag.name
@@ -131,7 +131,7 @@ class Api::V1::Shopkeeper::ItemTagsControllerTest < ActionDispatch::IntegrationT
   end
 
   # destroy
-  test "destroy deletes an item_tag" do
+  test "destroy deletes item_tag" do
     assert_difference "ItemTag.count", -1 do
       delete api_v1_shopkeeper_item_tag_url(@item_tag),
         headers: @shopkeeper.create_new_auth_token
@@ -149,7 +149,7 @@ class Api::V1::Shopkeeper::ItemTagsControllerTest < ActionDispatch::IntegrationT
   end
 
   # complete
-  test "complete completes an item_tag" do
+  test "complete completes item_tag" do
     patch complete_api_v1_shopkeeper_item_tag_url(@item_tag), headers: @shopkeeper.create_new_auth_token
     assert_response :success
     assert @item_tag.reload.completed?
@@ -165,7 +165,7 @@ class Api::V1::Shopkeeper::ItemTagsControllerTest < ActionDispatch::IntegrationT
   end
 
   # idle
-  test "idle resets an item_tag" do
+  test "idle resets item_tag" do
     @item_tag.complete!
     assert @item_tag.reload.completed?
 

--- a/test/controllers/api/v1/shopkeeper/shops_controller_test.rb
+++ b/test/controllers/api/v1/shopkeeper/shops_controller_test.rb
@@ -21,7 +21,7 @@ class Api::V1::Shopkeeper::ShopsControllerTest < ActionDispatch::IntegrationTest
   end
 
   # show
-  test "show returns a shop detail" do
+  test "show returns shop detail" do
     get api_v1_shopkeeper_shop_url(@shop), headers: @shopkeeper.create_new_auth_token
     assert_response :success
     assert_equal response.parsed_body["data"]["attributes"]["name"], @shop.name
@@ -72,7 +72,7 @@ class Api::V1::Shopkeeper::ShopsControllerTest < ActionDispatch::IntegrationTest
   end
 
   # destroy
-  test "destroy deletes a shop" do
+  test "destroy deletes shop" do
     assert_difference "Shop.count", -1 do
       delete api_v1_shopkeeper_shop_url(@shop),
         headers: @shopkeeper.create_new_auth_token

--- a/test/models/accounts_invitation_test.rb
+++ b/test/models/accounts_invitation_test.rb
@@ -167,7 +167,7 @@ class AccountsInvitationTest < ActiveSupport::TestCase
       member: true
     )
 
-    # Create a shopkeeper that's already a member
+    # Create shopkeeper that's already a member
     other_shopkeeper = shopkeepers(:two)
     AccountsShopkeeper.create!(
       account: @account,

--- a/test/models/shop_test.rb
+++ b/test/models/shop_test.rb
@@ -28,7 +28,7 @@ class ShopTest < ActiveSupport::TestCase
     assert_equal @shopkeeper, shop.created_by
   end
 
-  test "creating a shop creates exactly one sample item tag" do
+  test "creating shop creates exactly one sample item tag" do
     ActsAsTenant.with_tenant(@account) do
       shop = @account.shops.create!(name: "Test Shop", created_by: @shopkeeper)
       assert_equal 1, shop.item_tags.count


### PR DESCRIPTION
## Summary
- Apply the [substrate rename-safety contract](https://github.com/nativeapptemplate/nativeapptemplate-agent/blob/main/docs/SUBSTRATE-CONTRACT.md): remove `a` / `an` / `the` directly preceding `Shop`, `Shopkeeper`, and `ItemTag` (any case form) so the agent's text-only rename pipeline can't produce article disagreements like "an patient" or "a office" when users pick consonant- or vowel-starting rename targets.
- Touches test descriptors (rule 4), code comments (rule 6), OpenAPI endpoint summaries (rule 1, scanned by the rename pipeline as `.yaml`), and substrate meta-docs.
- No app code, locales, or model strings needed changes — the substrate was already mostly contract-compliant outside `docs/` and `test/`.

## Changes
- **Test descriptors** (7): `test/controllers/api/v1/shopkeeper/{item_tags,shops}_controller_test.rb`, `test/models/shop_test.rb`
- **Comments** (2): `test/controllers/api/v1/shopkeeper/base_controller_test.rb`, `test/models/accounts_invitation_test.rb`
- **OpenAPI summaries** (12): `docs/openapi.yaml`
- **Substrate meta-docs** (7): `docs/phase1-rails-api.md`, `docs/nativeapptemplate-substrate-v2-overview.md`

## Test plan
- [x] `bin/rubocop` — 227 files inspected, no offenses
- [x] `bin/rails test` — 398 runs, 815 assertions, 0 failures, 0 errors, 0 skips
- [ ] Spot-check rename pipeline output for an `ItemTag → Patient` (consonant) substitution and confirm no "an patient" / "an Patient" leaks remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)