### PR TITLE
Wire ItemTagNotifier to AASM complete event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Wire `ItemTagNotifier` to the `ItemTag` AASM `complete` event via `after_commit`. On state transition `idled → completed`, the notifier fires to all shopkeepers in the shop's account except the completer (`completed_by`). Only the AASM trigger — APNs/FCM provider credentials still pending (`bin/rails credentials:edit` once the keys are provisioned).
 - Drop the standalone `Device` model and consolidate push-token registration onto `ApplicationPushDevice` (subclass of `ActionPushNative::Device`) so `deliver_by :action_push_native` actually fires for tokens registered via `POST /api/v1/shopkeeper/devices`. The custom `devices` table is dropped; `action_push_native_devices` is rebuilt with UUID primary key + UUID polymorphic owner + `bundle_id` / `last_active_at` columns + unique `(platform, token)` index.
 - API contract change (still pre-mobile-client): `device.platform` enum is now `[apple, google]` (matches Action Push Native's APNs/FCM service convention) instead of `[ios, android]`. Mobile substrate clients (PRs #3-5) will register with `apple` or `google`.
 - Renames: `Device` → `ApplicationPushDevice`, `Api::Shopkeeper::DevicePolicy` → `Api::Shopkeeper::ApplicationPushDevicePolicy`, `DeviceSerializer` → `ApplicationPushDeviceSerializer` (JSONAPI `type` stays `device`); `Shopkeeper has_many :devices` → `has_many :application_push_devices, as: :owner`.

--- a/app/models/item_tag.rb
+++ b/app/models/item_tag.rb
@@ -24,10 +24,19 @@ class ItemTag < ApplicationRecord
 
     event :complete do
       transitions from: [:idled], to: :completed
+      after_commit :notify_completed
     end
   end
 
   private
+
+  def notify_completed
+    recipients = shop.account.shopkeepers
+    recipients = recipients.where.not(id: completed_by_id) if completed_by_id.present?
+    return if recipients.empty?
+
+    ItemTagNotifier.with(record: self).deliver(recipients)
+  end
 
   def set_default_position
     return if position.present?

--- a/test/models/item_tag_test.rb
+++ b/test/models/item_tag_test.rb
@@ -119,4 +119,61 @@ class ItemTagTest < ActiveSupport::TestCase
       assert item_tag.idled?
     end
   end
+
+  test "complete! fires ItemTagNotifier to all account shopkeepers except completer" do
+    ActsAsTenant.with_tenant(@account) do
+      other = shopkeepers(:two)
+      AccountsShopkeeper.create!(account: @account, shopkeeper: other, roles: {member: true})
+
+      item_tag = @shop.item_tags.first
+      item_tag.completed_by = @shopkeeper
+
+      assert_difference -> { Noticed::Event.count }, 1 do
+        assert_difference -> { Noticed::Notification.count }, 1 do
+          item_tag.complete!
+        end
+      end
+
+      notification = Noticed::Notification.last
+      assert_equal other, notification.recipient
+      assert_equal item_tag, notification.record
+    end
+  end
+
+  test "complete! fires notifier to all shopkeepers when completed_by is unset" do
+    ActsAsTenant.with_tenant(@account) do
+      other = shopkeepers(:two)
+      AccountsShopkeeper.create!(account: @account, shopkeeper: other, roles: {member: true})
+
+      item_tag = @shop.item_tags.first
+
+      assert_difference -> { Noticed::Notification.count }, 2 do
+        item_tag.complete!
+      end
+    end
+  end
+
+  test "complete! is a no-op for the notifier when account has only the completer" do
+    ActsAsTenant.with_tenant(@account) do
+      item_tag = @shop.item_tags.first
+      item_tag.completed_by = @shopkeeper
+
+      assert_no_difference -> { Noticed::Event.count } do
+        assert_no_difference -> { Noticed::Notification.count } do
+          item_tag.complete!
+        end
+      end
+    end
+  end
+
+  test "idle! does not fire ItemTagNotifier" do
+    ActsAsTenant.with_tenant(@account) do
+      item_tag = @shop.item_tags.first
+      item_tag.complete!
+
+      assert_no_difference -> { Noticed::Event.count } do
+        item_tag.idle!
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary
Closes the AASM-trigger half of [issue #58](https://github.com/nativeapptemplate/nativeapptemplateapi/issues/58) PR #2 scope.

`ItemTag` now fires `ItemTagNotifier` on the `complete` AASM event via `after_commit`. Recipients are all shopkeepers in the shop's account, **excluding** the completer (`completed_by`). `idle!` does not fire.

```ruby
event :complete do
  transitions from: [:idled], to: :completed
  after_commit :notify_completed
end

def notify_completed
  recipients = shop.account.shopkeepers
  recipients = recipients.where.not(id: completed_by_id) if completed_by_id.present?
  return if recipients.empty?
  ItemTagNotifier.with(record: self).deliver(recipients)
end
```

## Out of scope
- **APNs `.p8` + FCM service account JSON**: still need provisioning (`bin/rails credentials:edit`). `ApplicationPushNotification.enabled` defaults to `!Rails.env.test?`, so the trigger is a no-op in tests and a runtime no-op in dev/prod until credentials are configured.
- **Free iOS/Android push registration**: intentionally absent (per issue #58 — the gate is "you have to write the client to use it"). Paid clients (PRs #3, #4 in the issue) are the next step.

## Test plan
- [x] 4 new test cases in `item_tag_test.rb`:
  - `complete!` fires notifier; recipient is the non-completer shopkeeper
  - `complete!` fires to all shopkeepers when `completed_by` is unset
  - `complete!` is a no-op when account has only the completer
  - `idle!` does not fire the notifier
- [x] `bin/rails test` — 423 runs, 884 assertions, 0 failures
- [x] `bin/rubocop` — 243 files, 0 offenses
- [x] `bin/brakeman` — 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)