### PR TITLE
Add iOS/Android push notification integration guides

### DIFF
--- a/docs/push-android-integration.md
+++ b/docs/push-android-integration.md
@@ -1,0 +1,287 @@
+# Push notifications: Android client integration
+
+How a paid Android substrate client (e.g. the closed-source `NativeAppTemplate` Android app) integrates with this API to receive push notifications via Firebase Cloud Messaging (FCM).
+
+This is the implementation guide for **PR #4** of [issue #58](https://github.com/nativeapptemplate/nativeapptemplateapi/issues/58). The free Android substrate intentionally does not get push registration code — push is a paid-edition feature, gated at the client layer (the API endpoint is open; the gate is "you have to write the client to use it").
+
+---
+
+## Scope summary
+
+| Concern | Where it lives |
+|---|---|
+| FCM service account JSON provisioning | This Rails repo's encrypted credentials (`bin/rails credentials:edit`) |
+| Notification payload composition | `ItemTagNotifier` in this repo |
+| Notification delivery | Action Push Native, fired by `ItemTag`'s AASM `complete` event |
+| Device token registration API | `POST /api/v1/shopkeeper/devices` (see [`docs/openapi.yaml`](openapi.yaml)) |
+| Android-side token receipt + lifecycle | The paid Android client (this doc) |
+| Permission UX (API 33+) | The paid Android client (this doc) |
+| Notification channels | The paid Android client (this doc) |
+| Foreground / background presentation | The paid Android client (this doc) |
+
+---
+
+## API contract recap
+
+The Android client posts the FCM registration token to the substrate after each successful registration:
+
+```
+POST /api/v1/shopkeeper/devices
+Content-Type: application/json
+Authorization headers: <devise_token_auth headers>
+
+{
+  "device": {
+    "token": "<FCM registration token>",
+    "platform": "google",
+    "bundle_id": "com.your.application.id"
+  }
+}
+```
+
+- **`platform: "google"`** — matches Action Push Native's FCM service convention. Do **not** send `"android"`.
+- **`bundle_id`** — optional but recommended; helps disambiguate when one shopkeeper uses multiple agent-generated app variants. Use the Android `applicationId`.
+- Idempotent: the server upserts on `(platform, token)`. First POST returns `201 Created`, subsequent re-registrations of the same `(platform, token)` return `200 OK` and refresh `last_active_at`.
+- If the same token previously belonged to another shopkeeper (e.g. user signed out + new user signed in on the same device), the server rebinds it to the current shopkeeper.
+
+On sign-out, the client should `DELETE /api/v1/shopkeeper/devices/:id` to unregister. The server returns `204 No Content`.
+
+Full schemas: see `Device`, `DeviceAttributes`, `DeviceCreateRequest` in [`docs/openapi.yaml`](openapi.yaml) and the `/devices` paths near the end.
+
+---
+
+## Firebase project setup
+
+In Firebase console:
+
+1. Create a Firebase project for the substrate's canonical bundle ID (`com.nativeapptemplate.*`). Agent-renamed apps create their own Firebase projects.
+2. Add an Android app to the project; download `google-services.json`.
+3. Place `google-services.json` at `app/google-services.json` (gitignored — it contains the project's API key, which is not strictly secret but should rotate per fork).
+4. Generate a **service account key** (Project settings → Service accounts → Generate new private key). The JSON file goes into the API's encrypted credentials at `Rails.application.credentials.action_push_native.fcm.encryption_key` (see `config/push.yml`); the `project_id` lives there too.
+
+Project-level `build.gradle.kts`:
+
+```kotlin
+plugins {
+    id("com.google.gms.google-services") version "4.4.2" apply false
+}
+```
+
+App-level `build.gradle.kts`:
+
+```kotlin
+plugins {
+    id("com.android.application")
+    id("com.google.gms.google-services")
+}
+
+dependencies {
+    implementation(platform("com.google.firebase:firebase-bom:33.4.0"))
+    implementation("com.google.firebase:firebase-messaging-ktx")
+}
+```
+
+The Rails server side is already wired up (PRs #59, #60, #61). The Android client is the missing piece.
+
+---
+
+## Manifest: permission, service, channel
+
+`AndroidManifest.xml`:
+
+```xml
+<!-- API 33+ requires runtime permission for notifications -->
+<uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
+<application ...>
+    <!-- FCM token + payload receiver -->
+    <service
+        android:name=".push.AppFirebaseMessagingService"
+        android:exported="false">
+        <intent-filter>
+            <action android:name="com.google.firebase.MESSAGING_EVENT" />
+        </intent-filter>
+    </service>
+
+    <!-- Optional: default notification channel + small icon -->
+    <meta-data
+        android:name="com.google.firebase.messaging.default_notification_channel_id"
+        android:value="@string/default_notification_channel_id" />
+    <meta-data
+        android:name="com.google.firebase.messaging.default_notification_icon"
+        android:resource="@drawable/ic_notification" />
+</application>
+```
+
+---
+
+## Permission UX (API 33+)
+
+On Android 13+, `POST_NOTIFICATIONS` is a runtime permission. Request at a moment that makes sense — after sign-in and feature exposure, not at first launch.
+
+```kotlin
+class PushPermissionRequester(private val activity: ComponentActivity) {
+    private val launcher = activity.registerForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        if (granted) registerForPush() else /* surface "open settings" affordance */
+    }
+
+    fun ensurePermission() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            registerForPush()
+            return
+        }
+        when (PackageManager.PERMISSION_GRANTED) {
+            ContextCompat.checkSelfPermission(activity, Manifest.permission.POST_NOTIFICATIONS) ->
+                registerForPush()
+            else ->
+                launcher.launch(Manifest.permission.POST_NOTIFICATIONS)
+        }
+    }
+}
+```
+
+If permission is denied, the FCM token still arrives via the service callback, but the system suppresses any UI. Decide whether to skip POSTing the token in that case (saves the round-trip) or POST it anyway (so the next permission grant Just Works without re-registration).
+
+---
+
+## Notification channels
+
+Required on API 26+. Create channels at app startup (idempotent):
+
+```kotlin
+class NotificationChannels(private val context: Context) {
+    fun ensure() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        val nm = context.getSystemService(NotificationManager::class.java)
+        val channel = NotificationChannel(
+            DEFAULT_CHANNEL_ID,
+            context.getString(R.string.default_channel_name),
+            NotificationManager.IMPORTANCE_DEFAULT
+        ).apply {
+            description = context.getString(R.string.default_channel_description)
+        }
+        nm.createNotificationChannel(channel)
+    }
+
+    companion object {
+        const val DEFAULT_CHANNEL_ID = "item_tag_completed"
+    }
+}
+```
+
+Reference `DEFAULT_CHANNEL_ID` from the manifest's `default_notification_channel_id` `meta-data` so FCM's "notification" payloads land in this channel without per-message channel config.
+
+---
+
+## Token lifecycle
+
+### 1. Token received (`FirebaseMessagingService`)
+
+```kotlin
+class AppFirebaseMessagingService : FirebaseMessagingService() {
+    override fun onNewToken(token: String) {
+        // Fires on first launch and whenever FCM rotates the token.
+        // Posting is best-effort; if not signed in, queue and retry on sign-in.
+        PushTokenSync.register(token)
+    }
+
+    override fun onMessageReceived(message: RemoteMessage) {
+        // Foreground delivery handler — see "Foreground & background" below.
+        NotificationPresenter.show(this, message)
+    }
+}
+```
+
+`PushTokenSync.register(token)` posts to `/api/v1/shopkeeper/devices` with `platform: "google"`. Cache the returned `device.id` in EncryptedSharedPreferences — you'll need it for the sign-out DELETE.
+
+### 2. Token refresh
+
+FCM may rotate the token at any time; `onNewToken` fires automatically. No need to poll. Optionally, on app startup *while signed in*, fetch the current token via `FirebaseMessaging.getInstance().token` and POST again — defends against the rare case where `onNewToken` was missed (e.g. user reinstalled the app).
+
+### 3. Sign-in (existing token, new shopkeeper)
+
+When a different user signs in on the same device, fetch the cached token and re-POST. The server rebinds the token to the new `current_shopkeeper` (single round-trip, atomic).
+
+### 4. Sign-out
+
+```kotlin
+suspend fun signOut() {
+    val deviceId = encryptedPrefs.getString(KEY_DEVICE_ID, null)
+    if (deviceId != null) {
+        runCatching { api.deleteDevice(deviceId) }
+    }
+    encryptedPrefs.edit { remove(KEY_DEVICE_ID) }
+    // ...rest of sign-out flow
+}
+```
+
+If the DELETE fails (network), don't block sign-out. The server's `last_active_at` staleness scope (90 days) eventually prunes orphaned tokens.
+
+Optionally also call `FirebaseMessaging.getInstance().deleteToken()` to fully invalidate the FCM token. Skip this if you want re-sign-in on the same device to be silent (no permission re-prompt, immediate token reuse).
+
+---
+
+## Foreground & background presentation
+
+The notifier (`ItemTagNotifier` in this repo) sends `title`, `body`, and `data: { url: <api path> }` via Action Push Native, which constructs the FCM payload as:
+
+- **Notification payload** (system shows automatically when app is backgrounded): `title`, `body`
+- **Data payload**: `url` (and any other `data:` keys)
+
+When the app is in the **foreground**, `onMessageReceived` is called with the `RemoteMessage` and the system does **not** show a notification automatically — the client must build it:
+
+```kotlin
+object NotificationPresenter {
+    fun show(context: Context, message: RemoteMessage) {
+        val title = message.notification?.title ?: message.data["title"] ?: return
+        val body = message.notification?.body ?: message.data["body"] ?: ""
+        val url = message.data["url"]
+
+        val intent = url?.let { DeepLinkRouter.intentFor(context, it) }
+            ?: Intent(context, MainActivity::class.java)
+        val pending = PendingIntent.getActivity(
+            context, 0, intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val notification = NotificationCompat.Builder(context, NotificationChannels.DEFAULT_CHANNEL_ID)
+            .setContentTitle(title)
+            .setContentText(body)
+            .setSmallIcon(R.drawable.ic_notification)
+            .setContentIntent(pending)
+            .setAutoCancel(true)
+            .build()
+
+        NotificationManagerCompat.from(context).notify(message.messageId.hashCode(), notification)
+    }
+}
+```
+
+When the app is in the **background or killed**, the system shows the notification automatically using the FCM `notification` payload; tapping it launches the activity declared in `getLaunchIntentForPackage` with the `data` keys as extras. Pull `url` from the launching `Intent` in `MainActivity#onCreate` / `onNewIntent` and route.
+
+The `data.url` is an API path (e.g. `/api/v1/shopkeeper/shops/:shop_id/item_tags/:id`) — the client maps it to its own navigation stack.
+
+---
+
+## Testing locally
+
+- **Triggering a push**: in the Rails console on a dev box with credentials provisioned, transition `ItemTag` from `idled` to `completed`:
+  ```ruby
+  it = ItemTag.find(...)
+  it.completed_by = some_other_shopkeeper  # not the recipient
+  it.complete!
+  ```
+  The recipient set is `it.shop.account.shopkeepers` minus `completed_by`. See `app/models/item_tag.rb#notify_completed`.
+- **Without provider credentials**: `ApplicationPushNotification.enabled` defaults to `!Rails.env.test?`. In dev/prod without credentials, delivery enqueues but fails at the FCM HTTP call. Watch the job logs.
+- **Without a real device**: emulators with Google Play Services receive FCM pushes fine. AVD images **without** Google Play (the AOSP images) cannot.
+
+---
+
+## Out of scope for this guide
+
+- **Notification grouping / summaries**: tune via `setGroup` if needed; not required for v1.
+- **Custom notification actions**: defer.
+- **In-app messaging** / Firebase Remote Config / Analytics: separate Firebase products; not part of push.
+- **Topic subscriptions** (`subscribeToTopic`): not used — push is per-recipient via the substrate's `Noticed::Notification` records, not topic-based.

--- a/docs/push-ios-integration.md
+++ b/docs/push-ios-integration.md
@@ -1,0 +1,189 @@
+# Push notifications: iOS client integration
+
+How a paid iOS substrate client (e.g. the closed-source `NativeAppTemplate` iOS app) integrates with this API to receive push notifications via APNs.
+
+This is the implementation guide for **PR #3** of [issue #58](https://github.com/nativeapptemplate/nativeapptemplateapi/issues/58). The free iOS substrate intentionally does not get push registration code — push is a paid-edition feature, gated at the client layer (the API endpoint is open; the gate is "you have to write the client to use it").
+
+---
+
+## Scope summary
+
+| Concern | Where it lives |
+|---|---|
+| APNs auth key (`.p8`) provisioning | This Rails repo's encrypted credentials (`bin/rails credentials:edit`) |
+| Notification payload composition | `ItemTagNotifier` in this repo |
+| Notification delivery | Action Push Native, fired by `ItemTag`'s AASM `complete` event |
+| Device token registration API | `POST /api/v1/shopkeeper/devices` (see [`docs/openapi.yaml`](openapi.yaml)) |
+| iOS-side token receipt + lifecycle | The paid iOS client (this doc) |
+| Permission UX | The paid iOS client (this doc) |
+| Foreground / background presentation | The paid iOS client (this doc) |
+
+---
+
+## API contract recap
+
+The iOS client posts the APNs device token to the substrate after each successful registration:
+
+```
+POST /api/v1/shopkeeper/devices
+Content-Type: application/json
+Authorization headers: <devise_token_auth headers>
+
+{
+  "device": {
+    "token": "<APNs device token, hex-encoded>",
+    "platform": "apple",
+    "bundle_id": "com.your.bundle.id"
+  }
+}
+```
+
+- **`platform: "apple"`** — matches Action Push Native's APNs service convention. Do **not** send `"ios"`.
+- **`bundle_id`** — optional but recommended; helps disambiguate when one shopkeeper uses multiple agent-generated app variants.
+- Idempotent: the server upserts on `(platform, token)`. First POST returns `201 Created`, subsequent re-registrations of the same `(platform, token)` return `200 OK` and refresh `last_active_at`.
+- If the same token previously belonged to another shopkeeper (e.g. user signed out + new user signed in on the same device), the server rebinds it to the current shopkeeper.
+
+On sign-out, the client should `DELETE /api/v1/shopkeeper/devices/:id` to unregister. The server returns `204 No Content`.
+
+Full schemas: see `Device`, `DeviceAttributes`, `DeviceCreateRequest` in [`docs/openapi.yaml`](openapi.yaml) and the `/devices` paths near the end.
+
+---
+
+## Capabilities & project setup
+
+In Xcode:
+
+1. Target → **Signing & Capabilities** → add **Push Notifications**.
+2. Target → **Signing & Capabilities** → add **Background Modes** → check **Remote notifications** if silent pushes are needed.
+3. In the Apple Developer portal, the bundle ID's App ID must have **Push Notifications** entitlement enabled.
+4. Provision an **APNs Authentication Key (.p8)** in App Store Connect → Keys. The substrate uses key-based auth (not certificate-based). Hand the `.p8`, key ID, and team ID to whoever maintains the API's encrypted credentials — they go in `Rails.application.credentials.action_push_native.apns.*` (see `config/push.yml`).
+
+The Rails server side is already wired up (PRs #59, #60, #61). The iOS client is the missing piece.
+
+---
+
+## Permission UX
+
+Request notification permission at a moment that makes sense for the user — typically after they've signed in and seen the feature's value, not at app first-launch.
+
+```swift
+import UserNotifications
+
+func requestPushAuthorization() async {
+    let center = UNUserNotificationCenter.current()
+    do {
+        let granted = try await center.requestAuthorization(options: [.alert, .badge, .sound])
+        guard granted else { return }
+        await MainActor.run {
+            UIApplication.shared.registerForRemoteNotifications()
+        }
+    } catch {
+        // log / surface to user as appropriate
+    }
+}
+```
+
+If the user previously denied, `requestAuthorization` returns `false` immediately and the system does not re-prompt. Surface a "open Settings" affordance in that case.
+
+---
+
+## Token lifecycle
+
+The four moments the iOS client cares about:
+
+### 1. Token received (`AppDelegate`)
+
+```swift
+func application(
+    _ application: UIApplication,
+    didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+) {
+    let token = deviceToken.map { String(format: "%02x", $0) }.joined()
+    Task { await PushTokenSync.shared.register(token: token) }
+}
+
+func application(
+    _ application: UIApplication,
+    didFailToRegisterForRemoteNotificationsWithError error: Error
+) {
+    // Common in Simulator / when network is offline. Log; surface only in dev.
+}
+```
+
+`PushTokenSync.register(token:)` posts to `/api/v1/shopkeeper/devices` with `platform: "apple"`. Cache the returned `device.id` in keychain — you'll need it for the sign-out DELETE.
+
+### 2. Token refreshed (silent)
+
+iOS may rotate the APNs token. Call `UIApplication.shared.registerForRemoteNotifications()` on every cold start *while signed in*; iOS will re-deliver the current token via `didRegisterForRemoteNotificationsWithDeviceToken`. The server's idempotent upsert handles re-POSTs cleanly.
+
+### 3. Sign-in (existing token, new shopkeeper)
+
+If a user signs out and a different user signs in on the same device, re-POST the cached token. The server rebinds the token to the new `current_shopkeeper`. Don't try to manage this by deleting + re-registering — the rebind path is simpler and atomic.
+
+### 4. Sign-out
+
+```swift
+func signOut() async {
+    if let deviceId = KeychainStore.devicePushId {
+        try? await api.delete("/api/v1/shopkeeper/devices/\(deviceId)")
+    }
+    KeychainStore.devicePushId = nil
+    // ...rest of sign-out flow
+}
+```
+
+If the DELETE fails (e.g. network), don't block sign-out. The server's `last_active_at` staleness scope (90 days) eventually prunes orphaned tokens.
+
+---
+
+## Foreground & background presentation
+
+The notifier (`ItemTagNotifier` in this repo) sends `title`, `body`, and `data: { url: <api path> }`.
+
+```swift
+extension AppDelegate: UNUserNotificationCenterDelegate {
+    // Foreground: ask iOS to show the banner anyway
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification
+    ) async -> UNNotificationPresentationOptions {
+        return [.banner, .sound, .badge]
+    }
+
+    // Tap: pull data.url and route to the right screen
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse
+    ) async {
+        let userInfo = response.notification.request.content.userInfo
+        if let url = userInfo["url"] as? String {
+            DeepLinkRouter.shared.handle(url)
+        }
+    }
+}
+```
+
+The `data.url` is an API path (e.g. `/api/v1/shopkeeper/shops/:shop_id/item_tags/:id`) — the client maps it to its own navigation stack.
+
+---
+
+## Testing locally
+
+- **In the simulator**: APNs registration calls `didFailToRegisterForRemoteNotificationsWithError` — by design. Use a real device for end-to-end testing, or stub `register(token:)` in dev builds with a fixed fake token to exercise the API call.
+- **Triggering a push**: in the Rails console on a dev box with credentials provisioned, transition `ItemTag` from `idled` to `completed`:
+  ```ruby
+  it = ItemTag.find(...)
+  it.completed_by = some_other_shopkeeper  # not the recipient
+  it.complete!
+  ```
+  The recipient set is `it.shop.account.shopkeepers` minus `completed_by`. See `app/models/item_tag.rb#notify_completed`.
+- **Without provider credentials**: `ApplicationPushNotification.enabled` defaults to `!Rails.env.test?`. In dev/prod without credentials, delivery enqueues but fails at the APNs HTTP call. Watch the job logs.
+
+---
+
+## Out of scope for this guide
+
+- **Notification grouping / threading**: tune via `thread_id` on the notifier if needed; not required for v1.
+- **Notification actions** (custom buttons): defer to a follow-up.
+- **Critical alerts** / **time-sensitive**: requires a separate Apple entitlement; defer.
+- **Notification Service Extension** (image attachments, modify-on-receive): not needed for the substrate's text-only payloads.


### PR DESCRIPTION
## Summary
Two implementation guides for paid iOS/Android substrate clients (issue #58 PRs #3, #4):

- **`docs/push-ios-integration.md`** — APNs registration in `AppDelegate`, permission UX, token lifecycle, foreground/background handlers, sign-out cleanup
- **`docs/push-android-integration.md`** — Firebase setup, `FirebaseMessagingService`, `POST_NOTIFICATIONS` permission for API 33+, notification channels, token sync, sign-out cleanup

## Scope split clarified in each doc
| Concern | This Rails repo | Client repo (this guide) |
|---|---|---|
| Provider credentials (APNs `.p8` / FCM service account) | ✅ | |
| `ItemTagNotifier` payload + AASM trigger | ✅ | |
| `POST /api/v1/shopkeeper/devices` API contract | ✅ (`docs/openapi.yaml`) | references it |
| Token receipt + lifecycle (POST/DELETE) | | ✅ |
| Permission UX | | ✅ |
| Foreground/background presentation | | ✅ |

Each guide includes:
- API contract recap with `platform: "apple"` / `"google"` (matches Action Push Native conventions, not `ios` / `android`)
- Capabilities / project setup
- Permission UX patterns
- 4-stage token lifecycle (receive · refresh · sign-in rebind · sign-out)
- Foreground vs background presentation
- Local testing tips (including how to trigger the notifier from the Rails console)
- Out-of-scope list (notification grouping, custom actions, Notification Service Extension, etc.)

Both guides follow the substrate rename-safety contract — no article-coupled domain words, so the agent's text-only rename pipeline won't produce article disagreements.

## Test plan
- [x] Markdown renders correctly in GitHub preview
- [x] Cross-references to `docs/openapi.yaml` and `app/models/item_tag.rb` resolve
- [x] No article-coupled domain noun violations (substrate rename-safety contract)

🤖 Generated with [Claude Code](https://claude.com/claude-code)