### PR TITLE
Ignore CVE-2026-40295 (devise Timeoutable open redirect)

### DIFF
--- a/config/bundler-audit.yml
+++ b/config/bundler-audit.yml
@@ -4,3 +4,6 @@
 ignore:
   # devise 5.0.3+ fixes this, but devise_token_auth ~> 1.2 pins devise < 5
   - CVE-2026-32700
+  # devise 5.0.4+ fixes an Open Redirect in Timeoutable; we don't enable
+  # :timeoutable on Shopkeeper, and devise_token_auth ~> 1.2 pins devise < 5
+  - CVE-2026-40295


### PR DESCRIPTION
## Summary
- devise 5.0.4 fixes [CVE-2026-40295](https://github.com/heartcombo/devise/security/advisories/GHSA-jp94-3292-c3xv) (Open Redirect via unvalidated `request.referrer` in the Timeoutable session timeout handler), but `devise_token_auth ~> 1.2` still pins `devise < 5`, so we can't upgrade.
- `:timeoutable` is not enabled on `Shopkeeper` (`app/models/shopkeeper.rb:5-6`), so the affected code path does not exist in this app.
- Same rationale as the existing `CVE-2026-32700` ignore entry.

## Test plan
- [ ] `bin/bundler-audit` reports "No vulnerabilities found"
- [ ] CI passes on this PR and on #66 after rebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)