### PR TITLE
Upgrade noticed to v3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,7 @@ gem "resend"
 # Push notifications via APNs (iOS) and FCM (Android). Provider integration
 # (apnotic + googleauth + initializer with credentials) lands in a follow-up
 # PR; this PR scaffolds the model + controller + base notifier only.
-gem "noticed", "~> 2.7"
+gem "noticed", "~> 3.0"
 # Fix LoadError: cannot load such file -- csv
 gem "csv", "~> 3.3"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -290,7 +290,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.3-x86_64-linux-gnu)
       racc (~> 1.4)
-    noticed (2.9.3)
+    noticed (3.0.0)
       rails (>= 6.1.0)
     orm_adapter (0.5.0)
     os (1.1.4)
@@ -530,7 +530,7 @@ DEPENDENCIES
   minitest-mock
   mission_control-jobs
   nokogiri (>= 1.12.5)
-  noticed (~> 2.7)
+  noticed (~> 3.0)
   overcommit
   pagy (~> 43)
   pg


### PR DESCRIPTION
## Summary
- Bump `noticed` 2.9.3 → 3.0.0 (`Gemfile` constraint `~> 2.7` → `~> 3.0`).
- The only breaking change in noticed 3.0.0 is dropping Rails 6.1 support — this app runs Rails 8.1, so it doesn't apply. The notifier API used by `ItemTagNotifier` (`deliver_by`, `notification_methods`, `config.devices`/`config.format`) is unchanged.
- Conservative update: only `noticed` moved in the lockfile.

## Test plan
- [x] `bin/rubocop` — no offenses
- [x] `bin/bundler-audit` — no vulnerabilities
- [x] `bin/rails test` — 423 runs, 0 failures
- [x] `test/notifiers/item_tag_notifier_test.rb` — 3 runs, 8 assertions, passing under v3

🤖 Generated with [Claude Code](https://claude.com/claude-code)