### PR TITLE
Fix is_admin returning nil for non-admin members

### DIFF
--- a/app/models/concerns/rolified.rb
+++ b/app/models/concerns/rolified.rb
@@ -23,7 +23,7 @@ module Rolified
       scope role, -> { where("roles @> ?", {role => true}.to_json) }
 
       define_method(:"#{role}=") { |value| super(ActiveRecord::Type::Boolean.new.cast(value)) }
-      define_method(:"#{role}?") { send(role) }
+      define_method(:"#{role}?") { !!send(role) }
     end
 
     # Store the roles in the roles json column and cast to booleans

--- a/test/models/accounts_shopkeeper_test.rb
+++ b/test/models/accounts_shopkeeper_test.rb
@@ -149,6 +149,18 @@ class AccountsShopkeeperTest < ActiveSupport::TestCase
     assert_not accounts_shopkeeper.member?
   end
 
+  test "role predicate returns false (not nil) when role key is absent" do
+    other_shopkeeper = shopkeepers(:two)
+    accounts_shopkeeper = AccountsShopkeeper.create!(
+      account: @account,
+      shopkeeper: other_shopkeeper,
+      member: true
+    )
+
+    assert_not accounts_shopkeeper.roles.key?("admin")
+    assert_equal false, accounts_shopkeeper.admin?
+  end
+
   test "active_roles returns array of active roles" do
     other_shopkeeper = shopkeepers(:two)
     accounts_shopkeeper = AccountsShopkeeper.create!(

--- a/test/serializers/account_serializer_test.rb
+++ b/test/serializers/account_serializer_test.rb
@@ -85,7 +85,7 @@ class AccountSerializerTest < ActiveSupport::TestCase
     serialized = serializer.serializable_hash
 
     attributes = serialized[:data][:attributes]
-    assert_not attributes[:is_admin]
+    assert_equal false, attributes[:is_admin]
   end
 
   test "should include owner relationship" do


### PR DESCRIPTION
## Summary
- `Rolified` (`app/models/concerns/rolified.rb`) cast role values to boolean in the **setter** but the **predicate getter** returned the raw `store_accessor` value. When a record's `roles` JSON lacks a given key — e.g. a member created with only `member: true` — `admin?` returned `nil` instead of `false`.
- That nil propagated: `AccountsShopkeeper#admin?` → `Account#admin?` (`account.rb:21`) → `AccountSerializer` `is_admin` (`account_serializer.rb:7`), so the API returned `is_admin: null` for non-admin members.
- Fix: coerce the predicate to a real boolean (`!!send(role)`). Safe for all consumers (`active_roles`, `owner_must_be_admin`, policy `active_roles.include?`), which treat nil/false identically.

## Tests
- New `accounts_shopkeeper_test` case asserting `admin?` is `false` (not nil) when the role key is absent.
- Tightened the serializer's non-admin test from `assert_not` (passed on nil, masking the bug) to `assert_equal false`.

## Test plan
- [x] `bin/rubocop` — no offenses
- [x] `bin/rails test` — 424 runs, 886 assertions, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)