### PR TITLE
Fix push notification delivery crashing on send

### DIFF
--- a/app/notifiers/item_tag_notifier.rb
+++ b/app/notifiers/item_tag_notifier.rb
@@ -4,10 +4,12 @@ class ItemTagNotifier < ApplicationNotifier
     config.format = -> {
       {
         title: title,
-        body: body,
-        data: {url: url}
+        body: body
       }
     }
+    config.with_data = -> { {url: url} }
+    config.with_apple = -> { {} }
+    config.with_google = -> { {} }
   end
 
   notification_methods do
@@ -20,10 +22,7 @@ class ItemTagNotifier < ApplicationNotifier
     end
 
     def url
-      Rails.application.routes.url_helpers.api_v1_shopkeeper_shop_item_tag_path(
-        shop_id: record.shop_id,
-        id: record.id
-      )
+      Rails.application.routes.url_helpers.api_v1_shopkeeper_item_tag_path(record.id)
     end
   end
 end

--- a/test/notifiers/item_tag_notifier_test.rb
+++ b/test/notifiers/item_tag_notifier_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class ItemTagNotifierTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
   setup do
     @shopkeeper = shopkeepers(:one)
     @shopkeeper.create_default_account
@@ -29,5 +31,25 @@ class ItemTagNotifierTest < ActiveSupport::TestCase
 
     assert_equal I18n.t("notifiers.item_tag.title", shop: @shop.name), notification.title
     assert_equal I18n.t("notifiers.item_tag.body", name: @item_tag.name), notification.body
+  end
+
+  test "url resolves to the shallow item_tag path" do
+    ItemTagNotifier.with(record: @item_tag).deliver(@shopkeeper)
+    notification = @shopkeeper.notifications.last
+
+    expected = Rails.application.routes.url_helpers.api_v1_shopkeeper_item_tag_path(@item_tag.id)
+    assert_equal expected, notification.url
+  end
+
+  test "action_push_native delivery performs without raising" do
+    ApplicationPushDevice.create!(owner: @shopkeeper, platform: "apple", token: "test-token")
+
+    # Performs the Noticed delivery job (where the payload is built) but not the
+    # ApplicationPushNotificationJob, so no real APNs/FCM request is made.
+    assert_nothing_raised do
+      perform_enqueued_jobs(except: ApplicationPushNotificationJob) do
+        ItemTagNotifier.with(record: @item_tag).deliver(@shopkeeper)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary
Push delivery via `ItemTagNotifier` raised `TypeError (no implicit conversion of nil into Hash)` in the Noticed `action_push_native` job. Two stacked bugs:

1. **nil options** — The notifier omitted `with_apple`, `with_google`, and `with_data`. Noticed's delivery method passes each to `ActionPushNative`, which does `{}.merge(option)` and raises when the option is `nil`. Now provided (empty hashes for apple/google, the `url` payload for data), matching [Noticed's canonical config](https://github.com/excid3/noticed/blob/main/docs/delivery_methods/action_push_native.md).
2. **wrong route helper (masked by #1)** — `url` called `api_v1_shopkeeper_shop_item_tag_path`, which doesn't exist: `item_tags` is declared `shallow: true` (`config/routes.rb:49-50`), so the show route is `api_v1_shopkeeper_item_tag_path(id)`. Fixed.

Not caused by the noticed v2→v3 bump — the v2.9.3 delivery method was byte-identical; push simply hadn't run end-to-end until credentials landed.

## Tests
Existing notifier tests only *enqueued* the notification and never *performed* the delivery job, so neither bug surfaced. Added:
- A test that performs the Noticed delivery job (excluding the real APNs/FCM send job) — verified it reproduces the exact production error on the unfixed code.
- A test pinning `url` to the shallow item_tag route.

## Test plan
- [x] `bin/rubocop` — no offenses
- [x] `bin/rails test` — 426 runs, 889 assertions, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)