### PR TITLE
Add push devices to madmin dashboard

### DIFF
--- a/app/controllers/madmin/application_push_devices_controller.rb
+++ b/app/controllers/madmin/application_push_devices_controller.rb
@@ -1,0 +1,4 @@
+module Madmin
+  class ApplicationPushDevicesController < Madmin::ResourceController
+  end
+end

--- a/app/madmin/resources/application_push_device_resource.rb
+++ b/app/madmin/resources/application_push_device_resource.rb
@@ -1,0 +1,19 @@
+class ApplicationPushDeviceResource < Madmin::Resource
+  # Attributes
+  attribute :id, form: false
+  attribute :platform
+  attribute :token
+  attribute :name
+  attribute :bundle_id
+  attribute :last_active_at, form: false
+  attribute :created_at, form: false
+  attribute :updated_at, form: false
+
+  # Associations
+  attribute :owner
+
+  # Customize the default sort column and direction.
+  def self.default_sort_column = "last_active_at"
+
+  def self.default_sort_direction = "desc"
+end

--- a/config/routes/madmin.rb
+++ b/config/routes/madmin.rb
@@ -7,6 +7,7 @@ namespace :madmin do
   resources :accounts_shopkeepers
   resources :shops
   resources :item_tags
+  resources :application_push_devices
   resources :roles
   resources :permissions
   resources :roles_permissions

--- a/test/controllers/madmin/application_push_devices_controller_test.rb
+++ b/test/controllers/madmin/application_push_devices_controller_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+class Madmin::ApplicationPushDevicesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @admin_user = AdminUser.create!(name: "Admin", email: "admin@example.com", password: "password")
+    @device = ApplicationPushDevice.create!(
+      owner: shopkeepers(:one),
+      platform: "apple",
+      token: "test-token"
+    )
+  end
+
+  def sign_in_admin
+    post admin_session_path, params: {email: @admin_user.email, password: "password"}
+  end
+
+  test "index renders for authenticated admin" do
+    sign_in_admin
+    get madmin_application_push_devices_path
+    assert_response :success
+  end
+
+  test "show renders for authenticated admin" do
+    sign_in_admin
+    get madmin_application_push_device_path(@device)
+    assert_response :success
+  end
+
+  test "redirects unauthenticated users" do
+    get madmin_application_push_devices_path
+    assert_redirected_to "/"
+  end
+end


### PR DESCRIPTION
## Summary
- `ApplicationPushDevice` (`action_push_native_devices`) had no madmin resource, so registered push devices weren't visible in `/madmin`. Added the resource, controller, and route — it appears in the dashboard nav automatically.
- Resource exposes `platform`, `token`, `name`, `bundle_id`, `last_active_at`, timestamps, and the polymorphic `owner`; sorted by `last_active_at desc`.

## Tests
- The project's first madmin controller tests: authenticated index + show render `:success` (covers the polymorphic `owner` column), and unauthenticated access redirects to `/`.

## Notes
- The `noticed_notifications` / `noticed_events` tables remain unregistered in madmin — out of scope here.

## Test plan
- [x] `bin/rubocop` — no offenses
- [x] `bin/rails test` — 429 runs, 894 assertions, 0 failures
- [ ] Visually confirm the index/show pages in `/madmin` (verified `200` via integration tests, not browser)

🤖 Generated with [Claude Code](https://claude.com/claude-code)