### PR TITLE
Add noticed events and notifications to madmin dashboard

### DIFF
--- a/app/controllers/madmin/noticed/events_controller.rb
+++ b/app/controllers/madmin/noticed/events_controller.rb
@@ -1,0 +1,4 @@
+module Madmin
+  class Noticed::EventsController < Madmin::ResourceController
+  end
+end

--- a/app/controllers/madmin/noticed/notifications_controller.rb
+++ b/app/controllers/madmin/noticed/notifications_controller.rb
@@ -1,0 +1,4 @@
+module Madmin
+  class Noticed::NotificationsController < Madmin::ResourceController
+  end
+end

--- a/app/madmin/resources/noticed/event_resource.rb
+++ b/app/madmin/resources/noticed/event_resource.rb
@@ -1,0 +1,18 @@
+class Noticed::EventResource < Madmin::Resource
+  # Attributes
+  attribute :id, form: false
+  attribute :type
+  attribute :params
+  attribute :notifications_count, form: false
+  attribute :created_at, form: false
+  attribute :updated_at, form: false
+
+  # Associations
+  attribute :record
+  attribute :notifications
+
+  # Customize the default sort column and direction.
+  def self.default_sort_column = "created_at"
+
+  def self.default_sort_direction = "desc"
+end

--- a/app/madmin/resources/noticed/notification_resource.rb
+++ b/app/madmin/resources/noticed/notification_resource.rb
@@ -1,0 +1,18 @@
+class Noticed::NotificationResource < Madmin::Resource
+  # Attributes
+  attribute :id, form: false
+  attribute :type
+  attribute :read_at
+  attribute :seen_at
+  attribute :created_at, form: false
+  attribute :updated_at, form: false
+
+  # Associations
+  attribute :event
+  attribute :recipient
+
+  # Customize the default sort column and direction.
+  def self.default_sort_column = "created_at"
+
+  def self.default_sort_direction = "desc"
+end

--- a/config/routes/madmin.rb
+++ b/config/routes/madmin.rb
@@ -8,6 +8,10 @@ namespace :madmin do
   resources :shops
   resources :item_tags
   resources :application_push_devices
+  namespace :noticed do
+    resources :events
+    resources :notifications
+  end
   resources :roles
   resources :permissions
   resources :roles_permissions

--- a/test/controllers/madmin/noticed/events_controller_test.rb
+++ b/test/controllers/madmin/noticed/events_controller_test.rb
@@ -1,0 +1,34 @@
+require "test_helper"
+
+class Madmin::Noticed::EventsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @admin_user = AdminUser.create!(name: "Admin", email: "admin@example.com", password: "password")
+
+    shopkeeper = shopkeepers(:one)
+    shopkeeper.create_default_account
+    item_tag = shopkeeper.created_shops.first.item_tags.first
+    ItemTagNotifier.with(record: item_tag).deliver(shopkeeper)
+    @event = Noticed::Event.last
+  end
+
+  def sign_in_admin
+    post admin_session_path, params: {email: @admin_user.email, password: "password"}
+  end
+
+  test "index renders for authenticated admin" do
+    sign_in_admin
+    get madmin_noticed_events_path
+    assert_response :success
+  end
+
+  test "show renders for authenticated admin" do
+    sign_in_admin
+    get madmin_noticed_event_path(@event)
+    assert_response :success
+  end
+
+  test "redirects unauthenticated users" do
+    get madmin_noticed_events_path
+    assert_redirected_to "/"
+  end
+end

--- a/test/controllers/madmin/noticed/notifications_controller_test.rb
+++ b/test/controllers/madmin/noticed/notifications_controller_test.rb
@@ -1,0 +1,34 @@
+require "test_helper"
+
+class Madmin::Noticed::NotificationsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @admin_user = AdminUser.create!(name: "Admin", email: "admin@example.com", password: "password")
+
+    shopkeeper = shopkeepers(:one)
+    shopkeeper.create_default_account
+    item_tag = shopkeeper.created_shops.first.item_tags.first
+    ItemTagNotifier.with(record: item_tag).deliver(shopkeeper)
+    @notification = shopkeeper.notifications.last
+  end
+
+  def sign_in_admin
+    post admin_session_path, params: {email: @admin_user.email, password: "password"}
+  end
+
+  test "index renders for authenticated admin" do
+    sign_in_admin
+    get madmin_noticed_notifications_path
+    assert_response :success
+  end
+
+  test "show renders for authenticated admin" do
+    sign_in_admin
+    get madmin_noticed_notification_path(@notification)
+    assert_response :success
+  end
+
+  test "redirects unauthenticated users" do
+    get madmin_noticed_notifications_path
+    assert_redirected_to "/"
+  end
+end


### PR DESCRIPTION
## Summary
- `noticed_events` and `noticed_notifications` had no madmin resources, so delivered notifications and their events weren't visible in `/madmin`. Registered both as namespaced resources (mirroring the `ActiveStorage` pattern).
- The notification's `event` association is now a clickable link to the event resource; from an event you can browse its `notifications` and originating `record`.
- `Noticed::NotificationResource`: `type`, `read_at`, `seen_at`, timestamps, `event` + polymorphic `recipient`.
- `Noticed::EventResource`: `type`, `params` (jsonb), `notifications_count`, timestamps, polymorphic `record` + `notifications`.

## Tests
- index/show render and unauthenticated-redirect tests for both resources.

## Test plan
- [x] `bin/rubocop` — no offenses
- [x] `bin/rails test` — 435 runs, 904 assertions, 0 failures
- [ ] Visually confirm the pages in `/madmin` (verified `200` via integration tests, not browser)

🤖 Generated with [Claude Code](https://claude.com/claude-code)