### PR TITLE
Connect to APNs sandbox server in development

### DIFF
--- a/config/push.yml
+++ b/config/push.yml
@@ -26,7 +26,13 @@ shared:
     # Please note that anything built directly from Xcode and loaded on your phone will have
     # the app generate DEVELOPMENT tokens, while everything else (TestFlight, Apple Store, ...)
     # will be considered as PRODUCTION environment.
-    # connect_to_development_server: <%= Rails.env.development? %>
+    #
+    # Without this, the gem defaults to the production APNs server. A Xcode
+    # debug build registers a sandbox token, and pushing it to the production
+    # server returns 400 BadDeviceToken, which the gem treats as TokenError and
+    # destroys the device. Match the server to the Rails environment so local
+    # development talks to the sandbox.
+    connect_to_development_server: <%= Rails.env.development? %>
 
   # Use bin/rails credentials:edit to set the fcm secrets under
   # action_push_native:fcm:{project_id, encryption_key}.

--- a/test/config/push_config_test.rb
+++ b/test/config/push_config_test.rb
@@ -1,0 +1,10 @@
+require "test_helper"
+
+class PushConfigTest < ActiveSupport::TestCase
+  test "apns connects to the sandbox server only in the development environment" do
+    config = ActionPushNative.config
+
+    assert config.key?(:apple), "expected push.yml to configure the :apple platform"
+    assert_equal Rails.env.development?, config.dig(:apple, :connect_to_development_server)
+  end
+end


### PR DESCRIPTION
## Summary
A registered iOS push device would be destroyed as soon as any notification fired (e.g. an Android client completing an item_tag, which pushes to all of the recipient's devices).

Root cause: `config/push.yml` left `connect_to_development_server` commented out, so the gem connected to the **production** APNs host in every environment (`httpx_session.rb` defaults to production when the flag is falsy). A Xcode debug build registers a **sandbox** device token; pushing it to the production APNs server returns `400 BadDeviceToken`, which the gem raises as `TokenError` and then **destroys the device** via the default `rescue_from(TokenError) { destroy! }`.

Fix: enable the gem's recommended default —
```yaml
connect_to_development_server: <%= Rails.env.development? %>
```
Local development now talks to the APNs **sandbox** host (matching Xcode debug builds), while staging/production keep the production host (matching TestFlight/App Store builds).

## Notes
- iOS/APNs-specific: FCM (Android) has no sandbox/production split and is unaffected.
- The `destroy!`-on-`TokenError` behavior is correct for genuinely stale tokens, so it's left as-is — the bug was the environment mismatch making valid tokens look invalid.

## Tests
- `test/config/push_config_test.rb` asserts the APNs config's `connect_to_development_server` tracks `Rails.env.development?` (fails if the line is left commented → nil).

## Test plan
- [x] `bin/rubocop` — no offenses
- [x] `bin/rails test` — 436 runs, 906 assertions, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)