### PR TITLE
Test google (FCM) device registration

### DIFF
--- a/test/controllers/api/v1/shopkeeper/devices_controller_test.rb
+++ b/test/controllers/api/v1/shopkeeper/devices_controller_test.rb
@@ -25,6 +25,29 @@ class Api::V1::Shopkeeper::DevicesControllerTest < ActionDispatch::IntegrationTe
     assert_equal "com.nativeapptemplate.example", attrs["bundle_id"]
   end
 
+  test "create registers a google (FCM) device and returns 201" do
+    assert_difference -> { ApplicationPushDevice.count }, 1 do
+      post api_v1_shopkeeper_devices_url,
+        params: {device: {token: "fcm-token-123", platform: "google", bundle_id: "com.nativeapptemplate.nativeapptemplate"}},
+        headers: @shopkeeper.create_new_auth_token
+    end
+    assert_response :created
+    attrs = response.parsed_body["data"]["attributes"]
+    assert_equal "fcm-token-123", attrs["token"]
+    assert_equal "google", attrs["platform"]
+    assert_equal "com.nativeapptemplate.nativeapptemplate", attrs["bundle_id"]
+  end
+
+  test "create returns 422 for an unsupported platform" do
+    assert_no_difference -> { ApplicationPushDevice.count } do
+      post api_v1_shopkeeper_devices_url,
+        params: {device: {token: "abc123", platform: "android"}},
+        headers: @shopkeeper.create_new_auth_token
+    end
+    assert_response :unprocessable_entity
+    assert_equal 422, response.parsed_body["code"]
+  end
+
   test "create with same (platform, token) does not duplicate and returns 200" do
     ApplicationPushDevice.create!(owner: @shopkeeper, token: "abc123", platform: "apple", last_active_at: 1.day.ago)
 


### PR DESCRIPTION
## Summary
The `devices_controller` tests only covered `apple`. Added coverage for the Android/FCM path:
- `google` (FCM) device registration returns 201 with the expected serialized attributes.
- An unsupported platform value like `android` is rejected with 422, documenting that clients must send the **provider** name (`google`/`apple`), not the OS name.

Test-only — no production change. This locks in the API contract proving Android device registration works server-side (the Android-not-registering issue was traced to the client/runtime FCM token fetch, not the API).

## Test plan
- [x] `bin/rubocop` — no offenses
- [x] `bin/rails test` — 438 runs, 916 assertions, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)