### PR TITLE
Bump faraday-net_http and marcel within constraints

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,7 +164,7 @@ GEM
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-net_http (3.4.2)
+    faraday-net_http (3.4.3)
       net-http (~> 0.5)
     ffi (1.17.4-aarch64-linux-gnu)
     ffi (1.17.4-arm-linux-gnu)
@@ -241,7 +241,7 @@ GEM
       importmap-rails
       rails (>= 7.1.0)
       turbo-rails
-    marcel (1.1.1)
+    marcel (1.2.1)
     matrix (0.4.3)
     mini_magick (5.3.1)
       logger


### PR DESCRIPTION
## Summary
- Conservative `bundle update` (Gemfile.lock only): faraday-net_http 3.4.2 → 3.4.3, marcel 1.1.1 → 1.2.1.
- `devise` (5.0.4) held back by `devise_token_auth ~> 1.2`; `image_processing` (2.0) handled in a separate PR since it requires adding `ruby-vips` explicitly.

## Test plan
- [x] `bin/rubocop` — no offenses
- [x] `bin/bundler-audit` — no vulnerabilities
- [x] `bin/rails test` — 438 runs, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)