### PR TITLE
Upgrade image_processing to 2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,10 @@ gem "tzinfo-data", platforms: %i[windows jruby]
 gem "bootsnap", ">= 1.4.2", require: false
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
-gem "image_processing", "~> 1.12"
+gem "image_processing", "~> 2.0"
+# image_processing 2.0 makes the image library a soft dependency; ruby-vips
+# is Active Storage's default variant processor, so require it explicitly.
+gem "ruby-vips"
 
 # Security update
 gem "nokogiri", ">= 1.12.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -199,9 +199,7 @@ GEM
       http-2 (>= 1.1.3)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
-    image_processing (1.14.0)
-      mini_magick (>= 4.9.5, < 6)
-      ruby-vips (>= 2.0.17, < 3)
+    image_processing (2.0.1)
     importmap-rails (2.2.3)
       actionpack (>= 6.0.0)
       activesupport (>= 6.0.0)
@@ -243,8 +241,6 @@ GEM
       turbo-rails
     marcel (1.2.1)
     matrix (0.4.3)
-    mini_magick (5.3.1)
-      logger
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
     minitest (6.0.6)
@@ -522,7 +518,7 @@ DEPENDENCIES
   debug
   devise_token_auth (~> 1.2, >= 1.2.6)
   erb_lint
-  image_processing (~> 1.12)
+  image_processing (~> 2.0)
   importmap-rails
   jsonapi-serializer
   madmin (~> 2.0)
@@ -541,6 +537,7 @@ DEPENDENCIES
   rails (~> 8.1)
   resend
   rubocop-rails-omakase
+  ruby-vips
   seed-fu (~> 2.3)
   selenium-webdriver (>= 4.20.1)
   solid_cable


### PR DESCRIPTION
## Summary
- Bump `image_processing` 1.14.0 → 2.0.1 (`Gemfile` constraint `~> 1.12` → `~> 2.0`).
- image_processing 2.0 makes `mini_magick`/`ruby-vips` **soft dependencies** (they were hard deps in 1.x), so they no longer come transitively. Added `ruby-vips` explicitly — it's Active Storage's default variant processor (`variant_processor = :vips`). Dropped `mini_magick` since the app uses vips.

## Breaking-change check
- No image variant/transform code in the app (no `resize_to_*`, `variant(...)`, MiniMagick/vips calls), so 2.0's API changes (removed `:compose`/`:geometry` on `#composite`, vips default tweaks) don't touch app code.
- Ruby 3.0+ requirement is satisfied (Ruby 4.0.3).

## Test plan
- [x] `ImageProcessing::Vips` loads; `variant_processor` is `vips`
- [x] End-to-end vips resize smoke test (100×80 → 50×40, aspect preserved)
- [x] `bin/rubocop` — no offenses
- [x] `bin/bundler-audit` — no vulnerabilities
- [x] `bin/brakeman` — no warnings
- [x] `bin/rails test` — 438 runs, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)