### PR TITLE
docs: link to nativeapptemplate-agent (generate a customized app from a spec)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Extracted from the Rails API backend for [MyTurnTag Creator for iOS](https://app
 
 For more information, visit [nativeapptemplate.com](https://nativeapptemplate.com).
 
+Want a customized backend generated for you? [nativeapptemplate-agent](https://github.com/nativeapptemplate/nativeapptemplate-agent) is a Claude Code agent that turns a one-sentence spec (e.g. *"a walk-in queue for a barbershop"*) into a coherent three-platform implementation — this Rails 8.1 API plus matching [SwiftUI iOS](https://github.com/nativeapptemplate/NativeAppTemplate-Free-iOS) and [Jetpack Compose Android](https://github.com/nativeapptemplate/NativeAppTemplate-Free-Android) apps — renamed and adapted to your domain, with validation built in.
+
 ## API Documentation
 
 [API Documentation](https://nativeapptemplate.com/api-docs/index.html)


### PR DESCRIPTION
Adds a short pointer from this repo to **[nativeapptemplate-agent](https://github.com/nativeapptemplate/nativeapptemplate-agent)** — the Claude Code agent that generates a customized three-platform app (Rails 8.1 API + SwiftUI iOS + Jetpack Compose Android) from a one-sentence spec.

Closes a funnel gap: the agent README already points at this template, but this repo did not point back. Placed in the existing cross-link zone near the top, matching the sibling-repo links already there.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)