### PR TITLE
Update gems

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -619,7 +619,7 @@ Lint/Loop:
 
 Lint/MissingCopEnableDirective:
   Enabled: true
-  MaximumRangeSize: .inf
+  MaxRangeSize: .inf
 
 Lint/MissingSuper:
   Enabled: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,7 +103,7 @@ GEM
       smart_properties
     bigdecimal (4.1.2)
     bindex (0.8.1)
-    bootsnap (1.25.0)
+    bootsnap (1.26.0)
       msgpack (~> 1.5)
     brakeman (8.0.6)
       racc
@@ -158,7 +158,7 @@ GEM
       rubocop (>= 1)
       smart_properties
     erubi (1.13.1)
-    et-orbi (1.4.1)
+    et-orbi (1.4.2)
       tzinfo
     faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
@@ -181,7 +181,7 @@ GEM
       base64 (~> 0.2)
       faraday (>= 1.0, < 3.a)
     google-logging-utils (0.2.0)
-    googleauth (1.17.3)
+    googleauth (1.17.4)
       faraday (>= 1.0, < 3.a)
       google-cloud-env (~> 2.2)
       google-logging-utils (~> 0.1)
@@ -190,16 +190,16 @@ GEM
       pstore (~> 0.1)
       signet (>= 0.16, < 2.a)
     hashdiff (1.2.1)
-    http-2 (1.2.1)
+    http-2 (1.2.2)
     httparty (0.24.2)
       csv
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
-    httpx (1.8.1)
+    httpx (1.8.3)
       http-2 (>= 1.2.0)
     i18n (1.15.2)
       concurrent-ruby (~> 1.0)
-    image_processing (2.0.3)
+    image_processing (2.1.0)
     importmap-rails (2.2.3)
       actionpack (>= 6.0.0)
       activesupport (>= 6.0.0)
@@ -246,7 +246,7 @@ GEM
       drb (~> 2.0)
       prism (~> 1.5)
     minitest-mock (5.27.0)
-    mission_control-jobs (1.1.0)
+    mission_control-jobs (1.2.0)
       actioncable (>= 7.1)
       actionpack (>= 7.1)
       activejob (>= 7.1)
@@ -266,7 +266,7 @@ GEM
       net-protocol
     net-pop (0.1.2)
       net-protocol
-    net-protocol (0.2.2)
+    net-protocol (0.3.0)
       timeout
     net-smtp (0.5.1)
       net-protocol
@@ -293,7 +293,7 @@ GEM
       childprocess (>= 0.6.3, < 6)
       iniparse (~> 1.4)
       rexml (>= 3.4.2)
-    pagy (43.6.1)
+    pagy (43.6.2)
       json
       uri
       yaml
@@ -364,7 +364,7 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.4.2)
-    rbs (4.1.3)
+    rbs (4.2.0)
       logger
       prism (>= 1.6.0)
       tsort
@@ -376,15 +376,15 @@ GEM
     regexp_parser (2.12.0)
     reline (0.7.0)
       io-console (~> 0.5)
-    resend (1.10.0)
+    resend (1.14.0)
       base64
       httparty (>= 0.22.0)
-    responders (3.2.0)
+    responders (3.2.1)
       actionpack (>= 7.0)
       railties (>= 7.0)
     rexml (3.4.4)
-    rubocop (1.89.0)
-      json (~> 2.3)
+    rubocop (1.90.0)
+      json (>= 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
       parallel (>= 1.10)
@@ -415,12 +415,12 @@ GEM
     ruby-vips (2.3.0)
       ffi (~> 1.12)
       logger
-    rubyzip (3.5.0)
+    rubyzip (3.6.0)
     securerandom (0.4.1)
     seed-fu (2.3.9)
       activerecord (>= 3.1)
       activesupport (>= 3.1)
-    selenium-webdriver (4.47.0)
+    selenium-webdriver (4.48.0)
       base64 (~> 0.2)
       logger (~> 1.4)
       rexml (~> 3.2, >= 3.2.5)
@@ -470,7 +470,7 @@ GEM
     unicode-emoji (4.2.0)
     uri (1.1.1)
     useragent (0.16.11)
-    valid_email2 (7.0.15)
+    valid_email2 (7.1.0)
       activemodel (>= 6.0)
       mail (~> 2.5)
     warden (1.2.9)
@@ -479,7 +479,7 @@ GEM
       actionview (>= 8.0.0)
       bindex (>= 0.4.0)
       railties (>= 8.0.0)
-    webmock (3.26.3)
+    webmock (3.26.4)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)


### PR DESCRIPTION
## Summary

Routine dependency refresh via `bundle update`. 18 gems updated:

| Gem | From | To |
| --- | --- | --- |
| mission_control-jobs | 1.1.0 | 1.2.0 |
| resend | 1.10.0 | 1.14.0 |
| rubocop | 1.89.0 | 1.90.0 |
| image_processing | 2.0.3 | 2.1.0 |
| valid_email2 | 7.0.15 | 7.1.0 |
| selenium-webdriver | 4.47.0 | 4.48.0 |
| rbs | 4.1.3 | 4.2.0 |
| rubyzip | 3.5.0 | 3.6.0 |
| bootsnap | 1.25.0 | 1.26.0 |
| httpx | 1.8.1 | 1.8.3 |
| googleauth | 1.17.3 | 1.17.4 |
| net-protocol | 0.2.2 | 0.3.0 |
| responders | 3.2.0 | 3.2.1 |
| webmock | 3.26.3 | 3.26.4 |
| pagy | 43.6.1 | 43.6.2 |
| et-orbi | 1.4.1 | 1.4.2 |
| http-2 | 1.2.1 | 1.2.2 |

## Config change

RuboCop 1.90 renamed `Lint/MissingCopEnableDirective`'s `MaximumRangeSize` parameter to `MaxRangeSize`. Renamed in `.rubocop.yml` to clear the obsolete-parameter warning that RuboCop now prints on every run.

## Held back

`marcel` stays on 1.2.1 (2.1.0 available) — `activestorage 8.1.3.1` pins `marcel (~> 1.0)`.

## Verification

- [x] `bin/rubocop` — 253 files, no offenses, no warnings
- [x] `bundle exec erb_lint --lint-all` — no errors
- [x] `bin/bundler-audit` — no vulnerabilities
- [x] `bin/brakeman` — 0 security warnings
- [x] `bin/rails test` — 438 runs, 916 assertions, 0 failures, 0 errors

`mission_control-jobs` 1.2.0 prints a post-install note about HTTP basic auth; already handled by `config/initializers/mission_control.rb`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KtWK5oVadjzzdyD8z7qeCK